### PR TITLE
feat: Sentence extraction and on-demand LLM generation (issues #8 and #9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ The Tome app will guide the user through this process.
 ## Specs
 
 ### Language Learning
-- [Source Knowledge Extraction](./docs/specs/language/source-knowledge-extraction.md) — full specification for data model, API endpoints, extraction workflow, and source type implementations
+- [Source Knowledge Extraction](./docs/specs/language/source-knowledge-extraction.md) — full specification for data model, API endpoints, extraction workflow (vocabulary + sentences), and source type implementations
+- [Sentence Generation](./docs/specs/language/sentence-generation.md) — on-demand LLM sentence generation using vocabulary words as seed material, including verification by a Danish language expert agent
 
 
 ## Dev Utilities

--- a/agent/sentence_extraction_agent.py
+++ b/agent/sentence_extraction_agent.py
@@ -1,0 +1,60 @@
+from typing import List
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from pydantic import BaseModel
+from totoms import TotoLogger
+
+from agent.util import _create_llm
+from config.config import MyConfig
+
+
+class SentencePair(BaseModel):
+    sentence: str
+    translation: str
+
+class SentencePairs(BaseModel):
+    sentences: List[SentencePair]
+
+
+class SentenceExtractionAgent:
+
+    def __init__(self, config: MyConfig):
+        self.config = config
+        self.hyperscaler = config.environment.hyperscaler
+
+    async def extract(self, chunk: str) -> SentencePairs:
+        """Extract sentence-translation pairs from a text chunk."""
+        logger = TotoLogger.get_instance()
+
+        llm = _create_llm(self.hyperscaler)
+
+        prompt = """
+            You are a language learning assistant specialising in Danish.
+
+            Read the following text and extract every complete sentence or meaningful phrase that is written in Danish.
+            For each sentence, provide its English translation.
+
+            Rules:
+            1. Only extract sentences that are ALREADY PRESENT in the text. Do NOT invent or synthesise new sentences.
+            2. If an English translation is already given in the text alongside the Danish sentence, use that translation.
+            3. If no translation is provided in the text, generate an accurate English translation yourself.
+            4. A sentence must be a complete phrase — not a single isolated word or a sentence fragment.
+            5. Exclude sentences that are entirely in English (only include Danish sentences).
+            6. Both 'sentence' and 'translation' must be non-empty strings.
+
+            Return a JSON object with a single key 'sentences' whose value is a list of objects,
+            each having 'sentence' (the Danish phrase) and 'translation' (the English translation).
+
+            Do not include any text outside the JSON object.
+        """
+
+        structured_llm = llm.with_structured_output(SentencePairs)
+        logger.log("", f"Extracting sentences from chunk (first 300 chars): {chunk[:300]!r}")
+
+        result: SentencePairs = await structured_llm.ainvoke([
+            SystemMessage(content=prompt),
+            HumanMessage(content="Extract Danish sentences and their translations from the following text:\n\n" + chunk),
+        ])  # type: ignore
+
+        logger.log("", f"Extracted {len(result.sentences)} sentences from chunk")
+        return result

--- a/agent/sentence_extraction_agent.py
+++ b/agent/sentence_extraction_agent.py
@@ -7,6 +7,10 @@ from totoms import TotoLogger
 from agent.util import _create_llm
 from config.config import MyConfig
 
+# Minimum number of words a sentence must have to be kept.
+# This is a backstop filter applied after the LLM responds.
+MIN_SENTENCE_WORD_COUNT = 4
+
 
 class SentencePair(BaseModel):
     sentence: str
@@ -31,21 +35,33 @@ class SentenceExtractionAgent:
         prompt = """
             You are a language learning assistant specialising in Danish.
 
-            Read the following text and extract every complete sentence or meaningful phrase that is written in Danish.
-            For each sentence, provide its English translation.
+            Read the following text and extract complete Danish sentences that a language learner could use as example sentences.
 
-            Rules:
-            1. Only extract sentences that are ALREADY PRESENT in the text. Do NOT invent or synthesise new sentences.
-            2. If an English translation is already given in the text alongside the Danish sentence, use that translation.
-            3. If no translation is provided in the text, generate an accurate English translation yourself.
-            4. A sentence must be a complete phrase — not a single isolated word or a sentence fragment.
-            5. Exclude sentences that are entirely in English (only include Danish sentences).
+            STRICT RULES — violating any rule means the entry must be excluded:
+            1. Only extract text that is ALREADY PRESENT in the source. Do NOT invent or synthesise anything.
+            2. A valid entry MUST be a grammatically complete sentence: it must have at least a subject and a conjugated verb.
+               Isolated words, noun phrases, adjectives, infinitive phrases, and sentence fragments are NEVER valid — exclude them.
+               Examples of INVALID entries (do NOT include these):
+                 - "En ø"  (noun phrase, no verb)
+                 - "øde"  (single adjective)
+                 - "Behagelig"  (single adjective)
+                 - "En oplevelse"  (noun phrase, no verb)
+                 - "Erfaring"  (single noun)
+               Examples of VALID entries (these are fine):
+                 - "Da jeg var barn, boede jeg i Milano."
+                 - "Du er strandet på en øde ø i et helt år."
+                 - "Jeg kan godt lide at læse."
+            3. A sentence must contain at least 4 words.
+            4. If an English translation is already given in the text alongside the Danish sentence, use that translation.
+               Otherwise, generate an accurate English translation.
+            5. Exclude any entry where the 'sentence' field is entirely in English.
             6. Both 'sentence' and 'translation' must be non-empty strings.
 
             Return a JSON object with a single key 'sentences' whose value is a list of objects,
-            each having 'sentence' (the Danish phrase) and 'translation' (the English translation).
+            each having 'sentence' (the Danish sentence) and 'translation' (the English translation).
 
             Do not include any text outside the JSON object.
+            If no valid sentences are found, return {"sentences": []}.
         """
 
         structured_llm = llm.with_structured_output(SentencePairs)
@@ -53,8 +69,17 @@ class SentenceExtractionAgent:
 
         result: SentencePairs = await structured_llm.ainvoke([
             SystemMessage(content=prompt),
-            HumanMessage(content="Extract Danish sentences and their translations from the following text:\n\n" + chunk),
+            HumanMessage(content="Extract complete Danish sentences from the following text:\n\n" + chunk),
         ])  # type: ignore
 
-        logger.log("", f"Extracted {len(result.sentences)} sentences from chunk")
-        return result
+        # Backstop: drop anything that doesn't meet the minimum word count
+        filtered = [
+            s for s in result.sentences
+            if len(s.sentence.split()) >= MIN_SENTENCE_WORD_COUNT
+        ]
+
+        if len(filtered) < len(result.sentences):
+            logger.log("", f"Filtered out {len(result.sentences) - len(filtered)} short entries (< {MIN_SENTENCE_WORD_COUNT} words)")
+
+        logger.log("", f"Extracted {len(filtered)} sentences from chunk")
+        return SentencePairs(sentences=filtered)

--- a/agent/sentence_generation_agent.py
+++ b/agent/sentence_generation_agent.py
@@ -1,0 +1,72 @@
+from typing import List
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from pydantic import BaseModel
+from totoms import TotoLogger
+
+from agent.util import _create_llm
+from config.config import MyConfig
+
+
+class GeneratedSentence(BaseModel):
+    sentence: str
+    translation: str
+
+class GeneratedSentences(BaseModel):
+    sentences: List[GeneratedSentence]
+
+
+class SentenceGenerationAgent:
+    """Generates one Danish sentence per seed word."""
+
+    def __init__(self, config: MyConfig):
+        self.config = config
+        self.hyperscaler = config.environment.hyperscaler
+
+    async def generate(self, seed_words: List[str]) -> GeneratedSentences:
+        """
+        Generate one sentence per seed word.
+
+        Each sentence must naturally use its assigned seed word (or a
+        grammatically appropriate inflected form of it). Sentences must be
+        realistic, meaningful Danish — not artificial constructions that force
+        unrelated vocabulary together.
+        """
+        logger = TotoLogger.get_instance()
+        llm = _create_llm(self.hyperscaler)
+
+        word_list = "\n".join(f"- {w}" for w in seed_words)
+
+        prompt = """
+            You are an expert Danish language teacher creating example sentences for language learners.
+
+            You will receive a list of Danish vocabulary words (or English words with their Danish equivalent).
+            For each word, generate exactly ONE natural Danish sentence that uses that word.
+
+            Rules:
+            1. Generate exactly one sentence per word — the same number of sentences as words provided.
+            2. Each sentence must contain the assigned seed word or a grammatically appropriate inflected/conjugated form of it.
+               For example, the word "at lave" (to make/do) may appear as "laver", "lavede", "lavet", "lav", etc.
+            3. Each sentence must be realistic and meaningful — something a native Danish speaker would genuinely say in everyday life.
+            4. Do NOT force multiple unrelated vocabulary words into the same sentence. If additional seed words happen to
+               fit naturally, that is fine, but it must never be the primary goal.
+            5. Each sentence must be a complete sentence (subject + verb), not a fragment or an isolated word.
+            6. Provide an accurate English translation for each sentence.
+
+            Return a JSON object with a single key 'sentences' whose value is a list of objects,
+            each having 'sentence' (the Danish sentence) and 'translation' (the English translation).
+            The list must have exactly as many entries as there are seed words.
+
+            Do not include any text outside the JSON object.
+        """
+
+        structured_llm = llm.with_structured_output(GeneratedSentences)
+        logger.log("", f"Generating sentences for {len(seed_words)} seed words")
+
+        result: GeneratedSentences = await structured_llm.ainvoke([
+            SystemMessage(content=prompt),
+            HumanMessage(content=f"Generate one Danish sentence for each of the following words:\n\n{word_list}"),
+        ])  # type: ignore
+
+        logger.log("", f"Generated {len(result.sentences)} sentences")
+        return result

--- a/agent/sentence_verification_agent.py
+++ b/agent/sentence_verification_agent.py
@@ -1,0 +1,67 @@
+from typing import List
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from pydantic import BaseModel
+from totoms import TotoLogger
+
+from agent.util import _create_llm
+from agent.sentence_generation_agent import GeneratedSentence
+from config.config import MyConfig
+
+
+class VerifiedSentences(BaseModel):
+    sentences: List[GeneratedSentence]
+
+
+class SentenceVerificationAgent:
+    """
+    Acts as a Danish language expert. Reviews generated sentences and returns
+    only those it considers grammatically correct and natural Danish.
+    The agent accepts or rejects each sentence as-is — it never rewrites.
+    """
+
+    def __init__(self, config: MyConfig):
+        self.config = config
+        self.hyperscaler = config.environment.hyperscaler
+
+    async def verify(self, sentences: List[GeneratedSentence]) -> VerifiedSentences:
+        """
+        Return only the sentences that pass the Danish language quality check.
+        Rejected sentences are simply omitted from the output.
+        """
+        logger = TotoLogger.get_instance()
+        llm = _create_llm(self.hyperscaler)
+
+        sentences_text = "\n".join(
+            f"{i + 1}. {s.sentence} / {s.translation}"
+            for i, s in enumerate(sentences)
+        )
+
+        prompt = """
+            You are an expert Danish language teacher and native speaker.
+
+            You will receive a list of Danish sentences, each paired with an English translation.
+            Your task is to review each sentence and decide whether it is:
+            - Grammatically correct Danish
+            - Natural and idiomatic (something a native speaker would actually say)
+            - Meaningful in a real-life context
+
+            For each sentence that passes all three criteria, include it in your output as-is (do NOT rewrite it).
+            Simply omit any sentence that fails even one criterion.
+
+            Return a JSON object with a single key 'sentences' whose value is a list of objects,
+            each having 'sentence' (the original Danish sentence) and 'translation' (the original English translation).
+
+            Do not include any text outside the JSON object.
+        """
+
+        structured_llm = llm.with_structured_output(VerifiedSentences)
+        logger.log("", f"Verifying {len(sentences)} sentences")
+
+        result: VerifiedSentences = await structured_llm.ainvoke([
+            SystemMessage(content=prompt),
+            HumanMessage(content=f"Review the following Danish sentences and return only the correct ones:\n\n{sentences_text}"),
+        ])  # type: ignore
+
+        logger.log("", f"Verification passed {len(result.sentences)}/{len(sentences)} sentences")
+        return result

--- a/agent/sentence_verification_agent.py
+++ b/agent/sentence_verification_agent.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Union
 
 from langchain_core.messages import HumanMessage, SystemMessage
 from pydantic import BaseModel
@@ -6,6 +6,7 @@ from totoms import TotoLogger
 
 from agent.util import _create_llm
 from agent.sentence_generation_agent import GeneratedSentence
+from agent.sentence_extraction_agent import SentencePair
 from config.config import MyConfig
 
 
@@ -13,10 +14,32 @@ class VerifiedSentences(BaseModel):
     sentences: List[GeneratedSentence]
 
 
+_VERIFICATION_PROMPT = """
+    You are an expert Danish language teacher and native speaker.
+
+    You will receive a list of sentences, each paired with an English translation.
+    Review each sentence and include it in your output ONLY if ALL of the following are true:
+    - It is entirely written in Danish — it must not contain words from other languages
+      (e.g., English words mixed into an otherwise Danish sentence are grounds for rejection)
+    - It is grammatically correct Danish
+    - It is natural and idiomatic (something a native speaker would actually say)
+    - It is meaningful in a real-life context
+
+    Accept or reject each sentence as-is — do NOT rewrite or correct anything.
+    Simply omit any sentence that fails even one criterion.
+
+    Return a JSON object with a single key 'sentences' whose value is a list of objects,
+    each having 'sentence' (the original Danish sentence) and 'translation' (the original English translation).
+
+    Do not include any text outside the JSON object.
+    If no sentences pass, return {"sentences": []}.
+"""
+
+
 class SentenceVerificationAgent:
     """
-    Acts as a Danish language expert. Reviews generated sentences and returns
-    only those it considers grammatically correct and natural Danish.
+    Acts as a Danish language expert. Reviews sentences (extracted or generated)
+    and returns only those that are grammatically correct, natural, and purely Danish.
     The agent accepts or rejects each sentence as-is — it never rewrites.
     """
 
@@ -25,10 +48,26 @@ class SentenceVerificationAgent:
         self.hyperscaler = config.environment.hyperscaler
 
     async def verify(self, sentences: List[GeneratedSentence]) -> VerifiedSentences:
+        """Verify generated sentences. Returns only the accepted ones."""
+        return await self._run_verification(sentences)
+
+    async def verify_extracted(self, sentences: List[SentencePair]) -> List[SentencePair]:
         """
-        Return only the sentences that pass the Danish language quality check.
-        Rejected sentences are simply omitted from the output.
+        Verify extracted sentences. Returns only the accepted ones as SentencePairs.
+        Rejects sentences with grammar errors, non-Danish words, or mixed-language content.
         """
+        if not sentences:
+            return []
+
+        # Convert to GeneratedSentence for the shared verification logic
+        as_generated = [GeneratedSentence(sentence=s.sentence, translation=s.translation) for s in sentences]
+        result = await self._run_verification(as_generated)
+
+        # Convert back to SentencePair
+        accepted_texts = {s.sentence for s in result.sentences}
+        return [s for s in sentences if s.sentence in accepted_texts]
+
+    async def _run_verification(self, sentences: List[GeneratedSentence]) -> VerifiedSentences:
         logger = TotoLogger.get_instance()
         llm = _create_llm(self.hyperscaler)
 
@@ -37,30 +76,12 @@ class SentenceVerificationAgent:
             for i, s in enumerate(sentences)
         )
 
-        prompt = """
-            You are an expert Danish language teacher and native speaker.
-
-            You will receive a list of Danish sentences, each paired with an English translation.
-            Your task is to review each sentence and decide whether it is:
-            - Grammatically correct Danish
-            - Natural and idiomatic (something a native speaker would actually say)
-            - Meaningful in a real-life context
-
-            For each sentence that passes all three criteria, include it in your output as-is (do NOT rewrite it).
-            Simply omit any sentence that fails even one criterion.
-
-            Return a JSON object with a single key 'sentences' whose value is a list of objects,
-            each having 'sentence' (the original Danish sentence) and 'translation' (the original English translation).
-
-            Do not include any text outside the JSON object.
-        """
-
         structured_llm = llm.with_structured_output(VerifiedSentences)
         logger.log("", f"Verifying {len(sentences)} sentences")
 
         result: VerifiedSentences = await structured_llm.ainvoke([
-            SystemMessage(content=prompt),
-            HumanMessage(content=f"Review the following Danish sentences and return only the correct ones:\n\n{sentences_text}"),
+            SystemMessage(content=_VERIFICATION_PROMPT),
+            HumanMessage(content=f"Review the following sentences and return only the correct Danish ones:\n\n{sentences_text}"),
         ])  # type: ignore
 
         logger.log("", f"Verification passed {len(result.sentences)}/{len(sentences)} sentences")

--- a/api/tome_language_api.py
+++ b/api/tome_language_api.py
@@ -55,3 +55,83 @@ def post_words( config: MyConfig, language: str, words: List[Word], source_id: s
         
         print(e)
         print(resp)
+        return (0, len(words))
+
+
+def post_sentences(
+    config: MyConfig,
+    language: str,
+    sentences: List[dict],
+    knowledge_source: str,
+    auth_header: str,
+    correlation_id: str,
+) -> Tuple[int, int]:
+    """
+    POST sentences to tome-ms-language's batch endpoint.
+    Returns (sentences_created, sentences_errored).
+    Raises an exception if the service is unreachable.
+    Does NOT raise on non-207 status — the caller decides how to handle that.
+    """
+    logger = TotoLogger.get_instance()
+
+    url = f"{config.tome_language_url}/sentences/{language}/batch"
+
+    headers = {
+        "Authorization": auth_header,
+        "x-correlation-id": correlation_id,
+        "Content-Type": "application/json",
+    }
+
+    payload = {
+        "sentences": [
+            {
+                "sentence": s["sentence"],
+                "translation": s["translation"],
+                "knowledgeSource": knowledge_source,
+            }
+            for s in sentences
+        ]
+    }
+
+    logger.log(correlation_id, f"Posting {len(sentences)} sentences to Tome Language API")
+    resp = requests.post(url, json=payload, headers=headers, timeout=30, verify=False)
+    logger.log(correlation_id, f"Sentences POST response status: {resp.status_code}")
+
+    try:
+        resp_data = resp.json()
+        created = sum(1 for r in resp_data.get("results", []) if r.get("status") == "created")
+        errored = sum(1 for r in resp_data.get("results", []) if r.get("status") == "error")
+        return (created, errored)
+    except Exception as e:
+        print(e)
+        return (0, len(sentences))
+
+
+def sample_words(
+    config: MyConfig,
+    language: str,
+    n: int,
+    auth_header: str,
+    correlation_id: str,
+) -> List[dict]:
+    """
+    GET a random sample of n vocabulary words from tome-ms-language.
+    Returns a list of word dicts. Raises on network error.
+    """
+    logger = TotoLogger.get_instance()
+
+    url = f"{config.tome_language_url}/vocabulary/{language}/words/sample?n={n}"
+
+    headers = {
+        "Authorization": auth_header,
+        "x-correlation-id": correlation_id,
+    }
+
+    logger.log(correlation_id, f"Sampling {n} words from Tome Language API")
+    resp = requests.get(url, headers=headers, timeout=15, verify=False)
+    resp.raise_for_status()
+
+    data = resp.json()
+    words = data.get("words", [])
+    logger.log(correlation_id, f"Sampled {len(words)} words")
+    return words

--- a/app.py
+++ b/app.py
@@ -18,6 +18,7 @@ from dlg.hello import say_hello
 from dlg.post_source import post_source
 from dlg.get_sources import get_sources
 from dlg.extract_knowledge import extract_knowledge
+from dlg.generate_sentences import generate_sentences
 
 def get_microservice_config() -> TotoMicroserviceConfiguration:
     """Create and return the microservice configuration."""
@@ -35,6 +36,7 @@ def get_microservice_config() -> TotoMicroserviceConfiguration:
                 APIEndpoint(method="POST", path="/sources", delegate=post_source),
                 APIEndpoint(method="GET", path="/sources", delegate=get_sources),
                 APIEndpoint(method="POST", path="/sources/{sourceId}/extract", delegate=extract_knowledge),
+                APIEndpoint(method="POST", path="/sentences/generate", delegate=generate_sentences),
             ]
         ),
     )

--- a/config/config.py
+++ b/config/config.py
@@ -6,6 +6,8 @@ from typing import Optional, Dict, List
 SUPPORTED_TYPES: List[str] = ["google_doc"]
 SUPPORTED_LANGUAGES: List[str] = ["danish"]
 
+MAX_GENERATION_ITERATIONS: int = 3
+
 
 class MyConfig(TotoControllerConfig):
     """Custom configuration for the tome-ms-sources service."""
@@ -42,6 +44,11 @@ class MyConfig(TotoControllerConfig):
     def supported_languages(self) -> List[str]:
         """Return the list of supported target languages."""
         return SUPPORTED_LANGUAGES
+
+    @property
+    def max_generation_iterations(self) -> int:
+        """Maximum number of generate→verify cycles (including the first pass)."""
+        return MAX_GENERATION_ITERATIONS
 
     @property
     def tome_language_url(self) -> Optional[str]:

--- a/dlg/extract_knowledge.py
+++ b/dlg/extract_knowledge.py
@@ -13,7 +13,8 @@ from fastapi import Request
 from fastapi.responses import JSONResponse
 from starlette import authentication
 from agent.extraction_agent import KnowledgeExtractionAgent, Word
-from api.tome_language_api import post_words
+from agent.sentence_extraction_agent import SentenceExtractionAgent, SentencePair
+from api.tome_language_api import post_words, post_sentences
 from config.config import MyConfig
 from config.prompts import get_prompt
 from langchain_text_splitters import RecursiveCharacterTextSplitter
@@ -78,7 +79,8 @@ async def extract_knowledge(request: Request, user_context: UserContext, exec_co
 
         if not content:
             return JSONResponse(
-                content={"sourceId": source_id, "wordsExtracted": 0, "wordsCreated": 0, "wordsErrored": 0},
+                content={"sourceId": source_id, "wordsExtracted": 0, "wordsCreated": 0, "wordsErrored": 0,
+                         "sentencesExtracted": 0, "sentencesCreated": 0, "sentencesErrored": 0},
                 status_code=200,
             )
 
@@ -88,10 +90,10 @@ async def extract_knowledge(request: Request, user_context: UserContext, exec_co
                 status_code=400,
             )
 
-        # ── Step 3: LLM extraction ─────────────────────────────────────────────────
+        # ── Step 3: LLM vocabulary extraction ─────────────────────────────────────
         chunks = _split_content(content)
         
-        all_pairs, all_failed = await _extract_from_chunks(chunks, source.language, config)
+        all_pairs, all_failed = await _extract_words_from_chunks(chunks, source.language, config)
         
         logger = TotoLogger.get_instance()
         logger.log("", f"Extracted {len(all_pairs)} total pairs")
@@ -106,22 +108,37 @@ async def extract_knowledge(request: Request, user_context: UserContext, exec_co
         # Deduplicate (case-insensitive on both fields)
         deduped = _deduplicate(all_pairs)
 
-        if not deduped:
-            return JSONResponse(
-                content={"sourceId": source_id, "wordsExtracted": 0, "wordsCreated": 0, "wordsErrored": 0},
-                status_code=200,
-            )
-            
         print(f"Extracted {len(all_pairs)} total pairs, {len(deduped)} after deduplication")
         print(f"Sample extracted pairs: {deduped[:5]}")
 
-        # ── Step 4: POST to tome-ms-language ──────────────────────────────────────
+        # ── Step 4: LLM sentence extraction ───────────────────────────────────────
+        all_sentence_pairs, sentences_all_failed = await _extract_sentences_from_chunks(chunks, source.language, config)
+        deduped_sentences = _deduplicate_sentences(all_sentence_pairs)
+        logger.log("", f"Extracted {len(deduped_sentences)} sentences after deduplication")
+
+        # ── Step 5: POST vocabulary to tome-ms-language ────────────────────────────
         auth_header = request.headers.get("Authorization", "")
         correlation_id = exec_context.cid
-        
-        words_created, words_errored = post_words(config, "danish", deduped, source_id, auth_header, correlation_id)
 
-        # ── Step 5: Update lastExtractedAt ─────────────────────────────────────────
+        words_created = 0
+        words_errored = 0
+        if deduped:
+            words_created, words_errored = post_words(config, "danish", deduped, source_id, auth_header, correlation_id)
+
+        # ── Step 6: POST sentences to tome-ms-language (non-fatal on failure) ──────
+        sentences_created = 0
+        sentences_errored = 0
+        if deduped_sentences:
+            try:
+                sentence_dicts = [{"sentence": s.sentence, "translation": s.translation} for s in deduped_sentences]
+                sentences_created, sentences_errored = post_sentences(
+                    config, "danish", sentence_dicts, source_id, auth_header, correlation_id
+                )
+            except Exception as exc:
+                logger.log(correlation_id, f"Failed to post sentences (non-fatal): {exc}")
+                sentences_errored = len(deduped_sentences)
+
+        # ── Step 7: Update lastExtractedAt ─────────────────────────────────────────
         timestamp = datetime.now(timezone.utc).isoformat()
         store.update_last_extracted_at(source_id, timestamp)
 
@@ -131,6 +148,9 @@ async def extract_knowledge(request: Request, user_context: UserContext, exec_co
             "wordsExtracted": len(deduped),
             "wordsCreated": words_created,
             "wordsErrored": words_errored,
+            "sentencesExtracted": len(deduped_sentences),
+            "sentencesCreated": sentences_created,
+            "sentencesErrored": sentences_errored,
         },
         status_code=200,
     )
@@ -152,7 +172,7 @@ def _split_content(content: str) -> List[str]:
     return splitter.split_text(content)
 
 
-async def _extract_from_chunks( chunks: List[str], language: str, config, ) -> Tuple[List[Word], bool]:
+async def _extract_words_from_chunks( chunks: List[str], language: str, config, ) -> Tuple[List[Word], bool]:
     """
     Run LLM extraction over every chunk.
 
@@ -209,6 +229,42 @@ def _deduplicate(pairs: List[Word]) -> List[Word]:
     result = []
     for pair in pairs:
         key = (pair.english.lower(), pair.translation.lower())
+        if key not in seen:
+            seen.add(key)
+            result.append(pair)
+    return result
+
+
+async def _extract_sentences_from_chunks(
+    chunks: List[str], language: str, config
+) -> Tuple[List[SentencePair], bool]:
+    """
+    Run sentence extraction over every chunk.
+    Returns (all_sentence_pairs, all_failed).
+    """
+    all_pairs: List[SentencePair] = []
+    failed_count = 0
+
+    agent = SentenceExtractionAgent(config)
+
+    for chunk in chunks:
+        try:
+            result = await agent.extract(chunk)
+            all_pairs.extend(result.sentences)
+        except Exception as exc:
+            logging.warning("Sentence extraction failed for chunk: %s", exc)
+            failed_count += 1
+
+    all_failed = failed_count == len(chunks) and len(chunks) > 0
+    return all_pairs, all_failed
+
+
+def _deduplicate_sentences(pairs: List[SentencePair]) -> List[SentencePair]:
+    """Remove duplicate sentences (case-insensitive on the Danish sentence)."""
+    seen: set = set()
+    result = []
+    for pair in pairs:
+        key = pair.sentence.lower()
         if key not in seen:
             seen.add(key)
             result.append(pair)

--- a/dlg/extract_knowledge.py
+++ b/dlg/extract_knowledge.py
@@ -14,6 +14,7 @@ from fastapi.responses import JSONResponse
 from starlette import authentication
 from agent.extraction_agent import KnowledgeExtractionAgent, Word
 from agent.sentence_extraction_agent import SentenceExtractionAgent, SentencePair
+from agent.sentence_verification_agent import SentenceVerificationAgent
 from api.tome_language_api import post_words, post_sentences
 from config.config import MyConfig
 from config.prompts import get_prompt
@@ -116,7 +117,16 @@ async def extract_knowledge(request: Request, user_context: UserContext, exec_co
         deduped_sentences = _deduplicate_sentences(all_sentence_pairs)
         logger.log("", f"Extracted {len(deduped_sentences)} sentences after deduplication")
 
-        # ── Step 5: POST vocabulary to tome-ms-language ────────────────────────────
+        # ── Step 5: Verify extracted sentences (drop mixed-language / incorrect Danish) ─
+        if deduped_sentences:
+            try:
+                verification_agent = SentenceVerificationAgent(config)
+                deduped_sentences = await verification_agent.verify_extracted(deduped_sentences)
+                logger.log("", f"{len(deduped_sentences)} sentences passed verification")
+            except Exception as exc:
+                logger.log("", f"Sentence verification failed (non-fatal, keeping unverified): {exc}")
+
+        # ── Step 6: POST vocabulary to tome-ms-language ────────────────────────────
         auth_header = request.headers.get("Authorization", "")
         correlation_id = exec_context.cid
 
@@ -125,7 +135,7 @@ async def extract_knowledge(request: Request, user_context: UserContext, exec_co
         if deduped:
             words_created, words_errored = post_words(config, "danish", deduped, source_id, auth_header, correlation_id)
 
-        # ── Step 6: POST sentences to tome-ms-language (non-fatal on failure) ──────
+        # ── Step 7: POST sentences to tome-ms-language (non-fatal on failure) ──────
         sentences_created = 0
         sentences_errored = 0
         if deduped_sentences:
@@ -138,7 +148,7 @@ async def extract_knowledge(request: Request, user_context: UserContext, exec_co
                 logger.log(correlation_id, f"Failed to post sentences (non-fatal): {exc}")
                 sentences_errored = len(deduped_sentences)
 
-        # ── Step 7: Update lastExtractedAt ─────────────────────────────────────────
+        # ── Step 8: Update lastExtractedAt ─────────────────────────────────────────
         timestamp = datetime.now(timezone.utc).isoformat()
         store.update_last_extracted_at(source_id, timestamp)
 

--- a/dlg/generate_sentences.py
+++ b/dlg/generate_sentences.py
@@ -1,0 +1,152 @@
+import logging
+from typing import List
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from totoms.TotoLogger import TotoLogger
+from totoms.TotoDelegateDecorator import toto_delegate
+from totoms.model import ExecutionContext, UserContext
+
+from agent.sentence_generation_agent import SentenceGenerationAgent, GeneratedSentence
+from agent.sentence_verification_agent import SentenceVerificationAgent
+from api.tome_language_api import post_sentences, sample_words
+from config.config import MyConfig
+
+
+@toto_delegate
+async def generate_sentences(request: Request, user_context: UserContext, exec_context: ExecutionContext):
+    """
+    POST /sentences/generate
+
+    Body: { "language": "danish", "count": 10 }
+
+    Samples `count` vocabulary words from tome-ms-language, generates one sentence per
+    word (using the LLM), verifies grammar/naturalness, and persists accepted sentences.
+    Rejected sentences trigger a resample+regenerate loop up to MAX_GENERATION_ITERATIONS.
+
+    Returns: { language, sentencesGenerated, sentencesCreated, sentencesErrored }
+    """
+    config: MyConfig = exec_context.config  # type: ignore
+    logger = TotoLogger.get_instance()
+
+    body = await request.json()
+    language: str = body.get("language", "")
+    count: int = body.get("count", 0)
+
+    # ── Validate ──────────────────────────────────────────────────────────────
+    if language not in config.supported_languages:
+        return JSONResponse(
+            content={"message": f"Unsupported language '{language}'. Supported: {config.supported_languages}"},
+            status_code=400,
+        )
+    if not isinstance(count, int) or not (1 <= count <= 50):
+        return JSONResponse(
+            content={"message": "count must be an integer between 1 and 50"},
+            status_code=400,
+        )
+
+    auth_header = request.headers.get("Authorization", "")
+    correlation_id = exec_context.cid
+
+    # ── Step 1: Sample seed words ─────────────────────────────────────────────
+    try:
+        seed_words = await _sample_words_async(config, language, count, auth_header, correlation_id)
+    except Exception as exc:
+        logger.log(correlation_id, f"Failed to sample words: {exc}")
+        return JSONResponse(content={"message": "Failed to sample seed words"}, status_code=502)
+
+    if not seed_words:
+        return JSONResponse(
+            content={
+                "language": language,
+                "sentencesGenerated": 0,
+                "sentencesCreated": 0,
+                "sentencesErrored": 0,
+            },
+            status_code=200,
+        )
+
+    generation_agent = SentenceGenerationAgent(config)
+    verification_agent = SentenceVerificationAgent(config)
+
+    accepted: List[GeneratedSentence] = []
+    pending_words = seed_words  # words still needing a valid sentence
+
+    # ── Steps 2+3: Generate → Verify loop ─────────────────────────────────────
+    for iteration in range(config.max_generation_iterations):
+        if not pending_words:
+            break
+
+        logger.log(correlation_id, f"Generation iteration {iteration + 1}/{config.max_generation_iterations} for {len(pending_words)} words")
+
+        # Generate one sentence per pending seed word
+        try:
+            word_strings = [w.get("english", str(w)) for w in pending_words]
+            generated_result = await generation_agent.generate(word_strings)
+            generated = generated_result.sentences
+        except Exception as exc:
+            logger.log(correlation_id, f"Generation failed on iteration {iteration + 1}: {exc}")
+            break
+
+        if not generated:
+            break
+
+        # Verify — keep only the accepted ones
+        try:
+            verified_result = await verification_agent.verify(generated)
+            newly_accepted = verified_result.sentences
+        except Exception as exc:
+            logger.log(correlation_id, f"Verification failed on iteration {iteration + 1}: {exc}")
+            break
+
+        accepted.extend(newly_accepted)
+
+        # Determine how many were rejected (approximation: generated − accepted this round)
+        rejected_count = len(generated) - len(newly_accepted)
+        logger.log(correlation_id, f"Iteration {iteration + 1}: {len(newly_accepted)} accepted, {rejected_count} rejected")
+
+        if rejected_count == 0 or iteration == config.max_generation_iterations - 1:
+            break
+
+        # Resample for the rejected sentences
+        try:
+            pending_words = await _sample_words_async(config, language, rejected_count, auth_header, correlation_id)
+        except Exception as exc:
+            logger.log(correlation_id, f"Resample failed: {exc}")
+            break
+
+    logger.log(correlation_id, f"Total accepted sentences: {len(accepted)}")
+
+    # ── Step 4: POST accepted sentences to tome-ms-language ───────────────────
+    sentences_created = 0
+    sentences_errored = 0
+
+    if accepted:
+        sentence_dicts = [{"sentence": s.sentence, "translation": s.translation} for s in accepted]
+        try:
+            sentences_created, sentences_errored = post_sentences(
+                config, language, sentence_dicts, "tome-agent", auth_header, correlation_id
+            )
+        except Exception as exc:
+            logger.log(correlation_id, f"Failed to post sentences: {exc}")
+            sentences_errored = len(accepted)
+
+    return JSONResponse(
+        content={
+            "language": language,
+            "sentencesGenerated": len(accepted),
+            "sentencesCreated": sentences_created,
+            "sentencesErrored": sentences_errored,
+        },
+        status_code=200,
+    )
+
+
+async def _sample_words_async(config, language, n, auth_header, correlation_id) -> list:
+    """Thin async wrapper — sample_words is sync (requests)."""
+    import asyncio
+
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(
+        None, lambda: sample_words(config, language, n, auth_header, correlation_id)
+    )

--- a/docs/specs/language/sentence-generation.md
+++ b/docs/specs/language/sentence-generation.md
@@ -67,7 +67,7 @@ Triggers on-demand sentence generation.
 
 Call `GET /tomelang/vocabulary/{language}/words/sample?n=M` on `tome-ms-language` to retrieve a random set of `M` vocabulary words.
 
-`M` is a service-level configuration value (default: `30`). It is not exposed in the request body — the caller only specifies how many sentences to generate (`count`), not how many words to seed the generator with.
+**Default:** `M = Ns` (the number of sentences requested). This means one seed word is sampled per desired sentence, and each sentence will be built around its own word. The value `M` may be overridden by a service-level configuration if needed.
 
 If the vocabulary is empty (the endpoint returns an empty list), skip Steps 2–4 and return `200` with all counts at `0`.
 
@@ -75,11 +75,15 @@ If the vocabulary is empty (the endpoint returns an empty list), skip Steps 2–
 
 Pass the sampled vocabulary words to a **dedicated sentence generation LangChain agent**. This agent is distinct from both the vocabulary extraction agent and the sentence extraction agent — it has its own prompt file.
 
-**Goal:** generate exactly `count` sentences in the target language (e.g. Danish). Each sentence must:
-- Be grammatically correct Danish.
-- Naturally use at least one of the sampled vocabulary words.
+**Goal:** generate exactly `Ns` sentences in the target language (e.g. Danish), one sentence per sampled word (since `M = Ns` by default). Each sentence must:
+
+- Be built around its assigned seed word — the sentence must naturally use that word (or a grammatically appropriate conjugated / inflected form of it).
+- Be **realistic and meaningful** — something a native speaker would genuinely say. The sentence must make sense in a real-life context.
+- **Not force multiple unrelated vocabulary words into the same sentence.** If additional sampled words happen to fit naturally and logically in the sentence, they may appear — but this must never be the primary goal, and artificial constructions are forbidden.
 - Have an English translation.
-- Be realistic, complete sentences — not single words or fragments.
+- Be a complete sentence — not a single word or a fragment.
+
+**Handling inflected forms:** Vocabulary words may be stored in their dictionary form. For example, verbs may appear as `"at lave"` (infinitive). The generated sentence must use the word in whatever grammatical form is appropriate for the sentence — e.g. `"at lave"` may appear as `laver`, `lavede`, `lavet`, `lav` etc. The seed word only constrains which word root must appear; it does not impose a specific conjugation.
 
 **Expected LLM output (structured / JSON mode):**
 
@@ -87,12 +91,12 @@ Pass the sampled vocabulary words to a **dedicated sentence generation LangChain
 {
   "sentences": [
     {
-      "sentence": "Jeg kan godt lide at læse bøger om dansk kultur.",
-      "translation": "I like reading books about Danish culture."
+      "sentence": "Jeg laver aftensmad i aften.",
+      "translation": "I am making dinner tonight."
     },
     {
-      "sentence": "Hun vænner sig langsomt til det kolde vejr.",
-      "translation": "She is slowly getting used to the cold weather."
+      "sentence": "Kom allesammen, jeg har lavet aftensmaden.",
+      "translation": "Come everyone, I have made dinner."
     }
   ]
 }
@@ -155,7 +159,7 @@ If `tome-ms-language` returns any status other than `207`, the request fails wit
 
 - The sentence generation agent and the verification agent each use their own **separate prompt files**. Prompts must be easy to tune without code changes.
 - The model and provider are defined in the service configuration (same pattern as the extraction agents).
-- The number of seed words `M` must be a service-level configuration value (not hardcoded).
+- The value of `M` defaults to `Ns` (computed at runtime). A service-level configuration override is allowed if a different ratio is ever needed.
 
 ---
 
@@ -177,10 +181,12 @@ The following endpoints are used:
 ## Business Rules
 
 1. **`count` cap:** A maximum of `50` sentences may be generated per request to limit LLM latency and cost.
-2. **Seed words:** The number of words sampled from vocabulary (`M`) is a server-side setting, decoupled from `count`. Using more seed words generally produces more varied sentences.
-3. **No deduplication:** The same sentence may be generated and stored multiple times across calls. Deduplication is out of scope.
-4. **Provenance:** All sentences produced by this workflow carry `knowledgeSource = "tome-agent"` so they can be distinguished from sentences extracted from source material.
-5. **Verification is mandatory:** The verification step (Step 3) cannot be bypassed. It ensures quality and guards against LLM hallucinations generating incorrect Danish.
+2. **Seed words — one per sentence:** By default `M = Ns`. Each sentence is generated around one seed word. This produces focused, natural sentences rather than forcing unrelated words together.
+3. **No forced word combinations:** Multiple seed words may appear in the same sentence only if they fit together naturally. The agent must never construct artificial sentences purely to include several vocabulary words.
+4. **Inflected forms are acceptable:** A seed word stored in dictionary form (e.g. `"at lave"`) may appear in any grammatically correct conjugated or inflected form in the generated sentence (e.g. `laver`, `lavede`, `lavet`). The generated sentence is not required to contain the exact stored string.
+5. **No deduplication:** The same sentence may be generated and stored multiple times across calls. Deduplication is out of scope.
+6. **Provenance:** All sentences produced by this workflow carry `knowledgeSource = "tome-agent"` so they can be distinguished from sentences extracted from source material.
+7. **Verification is mandatory:** The verification step (Step 3) cannot be bypassed. It ensures quality and guards against LLM hallucinations generating incorrect Danish.
 
 ---
 

--- a/docs/specs/language/sentence-generation.md
+++ b/docs/specs/language/sentence-generation.md
@@ -1,0 +1,193 @@
+# Sentence Generation — Feature Spec
+
+## Overview
+
+This spec defines the on-demand **sentence generation** capability in `tome-ms-sources`.
+
+While [Source Knowledge Extraction](./source-knowledge-extraction.md) extracts sentences that are already present in user-provided source material, sentence generation creates **new sentences** using an LLM agent. The agent uses existing vocabulary words from `tome-ms-language` as seed material, generates fluent Danish sentences that use those words, and stores them back in `tome-ms-language`.
+
+Generated sentences are distinguished from extracted sentences by the `knowledgeSource` value `"tome-agent"`.
+
+---
+
+## API Endpoint
+
+### POST `/sentences/generate` — GenerateSentences
+
+Triggers on-demand sentence generation.
+
+#### Request Body
+
+```json
+{
+  "language": "danish",
+  "count": 10
+}
+```
+
+| Field      | Required | Description                                                                        |
+|------------|----------|------------------------------------------------------------------------------------|
+| `language` | Yes      | Target language (e.g. `"danish"`). Must be in the supported language list.         |
+| `count`    | Yes      | Number of sentences to generate (`Ns`). Must be a positive integer. Maximum: `50`. |
+
+#### Response — `200 OK`
+
+```json
+{
+  "language": "danish",
+  "sentencesGenerated": 10,
+  "sentencesCreated": 9,
+  "sentencesErrored": 1
+}
+```
+
+| Field                | Description                                                                             |
+|----------------------|-----------------------------------------------------------------------------------------|
+| `sentencesGenerated` | Number of valid sentences produced by the generation agent (after the verification pass) |
+| `sentencesCreated`   | Sentences reported as `"created"` by `tome-ms-language` in the `207` response           |
+| `sentencesErrored`   | Sentences reported as `"error"` by `tome-ms-language` in the `207` response             |
+
+#### Error Cases
+
+| Condition                          | Status | Description                                              |
+|------------------------------------|--------|----------------------------------------------------------|
+| Missing `language` or `count`      | `400`  | Required fields not provided                             |
+| Unsupported `language`             | `400`  | Language is not in the supported list                    |
+| `count` ≤ 0 or > 50               | `400`  | Count is out of the allowed range                        |
+| No vocabulary words available      | `200`  | Vocabulary is empty; all counts will be `0`              |
+| LLM generation agent fails         | `502`  | LLM agent fails after retry                              |
+| LLM verification agent fails       | `502`  | Verification agent fails after retry                     |
+| `tome-ms-language` unreachable     | `502`  | The downstream service is unreachable                    |
+
+---
+
+## Generation Workflow
+
+### Step 1 — Sample Vocabulary Words
+
+Call `GET /tomelang/vocabulary/{language}/words/sample?n=M` on `tome-ms-language` to retrieve a random set of `M` vocabulary words.
+
+`M` is a service-level configuration value (default: `30`). It is not exposed in the request body — the caller only specifies how many sentences to generate (`count`), not how many words to seed the generator with.
+
+If the vocabulary is empty (the endpoint returns an empty list), skip Steps 2–4 and return `200` with all counts at `0`.
+
+### Step 2 — LLM Sentence Generation Agent
+
+Pass the sampled vocabulary words to a **dedicated sentence generation LangChain agent**. This agent is distinct from both the vocabulary extraction agent and the sentence extraction agent — it has its own prompt file.
+
+**Goal:** generate exactly `count` sentences in the target language (e.g. Danish). Each sentence must:
+- Be grammatically correct Danish.
+- Naturally use at least one of the sampled vocabulary words.
+- Have an English translation.
+- Be realistic, complete sentences — not single words or fragments.
+
+**Expected LLM output (structured / JSON mode):**
+
+```json
+{
+  "sentences": [
+    {
+      "sentence": "Jeg kan godt lide at læse bøger om dansk kultur.",
+      "translation": "I like reading books about Danish culture."
+    },
+    {
+      "sentence": "Hun vænner sig langsomt til det kolde vejr.",
+      "translation": "She is slowly getting used to the cold weather."
+    }
+  ]
+}
+```
+
+**Validation:** each entry must have both `sentence` and `translation` as non-empty strings. Entries that fail this check are silently dropped.
+
+**LLM failure handling:** one retry on failure; return `502` if the retry also fails.
+
+### Step 3 — Danish Language Expert Verification Agent
+
+Pass all generated sentences from Step 2 through a **second LLM agent** that acts as a Danish language expert. This agent's sole purpose is to verify grammatical and linguistic correctness. It reviews each sentence and returns only the sentences it considers correct Danish.
+
+**Goal:** filter out any sentences that are grammatically wrong, unnatural, or implausible in Danish. The agent should not rewrite sentences — it either accepts or rejects each one as-is.
+
+**Expected LLM output (structured / JSON mode):**
+
+```json
+{
+  "sentences": [
+    {
+      "sentence": "Jeg kan godt lide at læse bøger om dansk kultur.",
+      "translation": "I like reading books about Danish culture."
+    }
+  ]
+}
+```
+
+The verified set may be smaller than the input set if some sentences were rejected.
+
+**LLM failure handling:** one retry on failure; return `502` if the retry also fails.
+
+> **Note:** If the verified set is empty (all sentences rejected), return `200` with all counts at `0`. This is a valid outcome, not an error.
+
+### Step 4 — Post Sentences to tome-ms-language
+
+Call `POST /tomelang/sentences/{language}/batch` on `tome-ms-language` with the verified sentences:
+
+```json
+{
+  "sentences": [
+    {
+      "sentence": "Jeg kan godt lide at læse bøger om dansk kultur.",
+      "translation": "I like reading books about Danish culture.",
+      "knowledgeSource": "tome-agent"
+    }
+  ]
+}
+```
+
+The `knowledgeSource` field must always be `"tome-agent"` for generated sentences.
+
+**Authentication and Correlation:** forward the user's JWT and include the correlation ID, same as the extraction workflow.
+
+If `tome-ms-language` returns any status other than `207`, the request fails with `502`.
+
+---
+
+## LLM Configuration
+
+- The sentence generation agent and the verification agent each use their own **separate prompt files**. Prompts must be easy to tune without code changes.
+- The model and provider are defined in the service configuration (same pattern as the extraction agents).
+- The number of seed words `M` must be a service-level configuration value (not hardcoded).
+
+---
+
+## Integration — tome-ms-language
+
+The following endpoints are used:
+
+| Method | Path                                             | Purpose                        |
+|--------|--------------------------------------------------|--------------------------------|
+| `GET`  | `/tomelang/vocabulary/{language}/words/sample`   | Fetch random seed vocabulary   |
+| `POST` | `/tomelang/sentences/{language}/batch`           | Store generated sentences      |
+
+**Authentication:** Forward the user's JWT from the incoming request as `Authorization: Bearer <token>`.
+
+**Traceability:** Include the execution context's correlation ID as `x-correlation-id`.
+
+---
+
+## Business Rules
+
+1. **`count` cap:** A maximum of `50` sentences may be generated per request to limit LLM latency and cost.
+2. **Seed words:** The number of words sampled from vocabulary (`M`) is a server-side setting, decoupled from `count`. Using more seed words generally produces more varied sentences.
+3. **No deduplication:** The same sentence may be generated and stored multiple times across calls. Deduplication is out of scope.
+4. **Provenance:** All sentences produced by this workflow carry `knowledgeSource = "tome-agent"` so they can be distinguished from sentences extracted from source material.
+5. **Verification is mandatory:** The verification step (Step 3) cannot be bypassed. It ensures quality and guards against LLM hallucinations generating incorrect Danish.
+
+---
+
+## Out of Scope
+
+- Scheduling or batch generation (generation is always user-triggered).
+- Sentence difficulty classification.
+- Targeting specific vocabulary words (the seed sample is random).
+- Re-generating or updating previously generated sentences.
+- Progress streaming for long-running generation.

--- a/docs/specs/language/sentence-generation.md
+++ b/docs/specs/language/sentence-generation.md
@@ -106,7 +106,7 @@ Pass the sampled vocabulary words to a **dedicated sentence generation LangChain
 
 **LLM failure handling:** one retry on failure; return `502` if the retry also fails.
 
-### Step 3 — Danish Language Expert Verification Agent
+### Step 3 — Danish Language Expert Verification Agent + Replacement Loop
 
 Pass all generated sentences from Step 2 through a **second LLM agent** that acts as a Danish language expert. This agent's sole purpose is to verify grammatical and linguistic correctness. It reviews each sentence and returns only the sentences it considers correct Danish.
 
@@ -129,7 +129,18 @@ The verified set may be smaller than the input set if some sentences were reject
 
 **LLM failure handling:** one retry on failure; return `502` if the retry also fails.
 
-> **Note:** If the verified set is empty (all sentences rejected), return `200` with all counts at `0`. This is a valid outcome, not an error.
+#### Replacement Loop
+
+If the verification agent rejects one or more sentences, the generation agent (Step 2) must be called again to produce replacements — one new sentence for each rejected one, using newly sampled seed words from `tome-ms-language` (one new word per replacement sentence, same as the default `M = Ns` rule). The new sentences are then passed back through the verification agent.
+
+This loop continues until one of the following conditions is met:
+
+1. **All `Ns` sentences have been accepted** by the verification agent.
+2. **The maximum number of loop iterations has been reached.** This limit is configured in the service `Config` class (`MAX_GENERATION_ITERATIONS`, default: `3`). Once the limit is reached, whatever sentences have been verified so far are accepted as the final set — even if fewer than `Ns`.
+
+> **Note:** The initial generation + verification pass counts as iteration 1. If `MAX_GENERATION_ITERATIONS = 3`, there can be at most 2 replacement rounds after the first pass.
+
+> **Note:** If the final verified set is empty (all sentences rejected across all iterations), return `200` with all counts at `0`. This is a valid outcome, not an error.
 
 ### Step 4 — Post Sentences to tome-ms-language
 
@@ -160,6 +171,7 @@ If `tome-ms-language` returns any status other than `207`, the request fails wit
 - The sentence generation agent and the verification agent each use their own **separate prompt files**. Prompts must be easy to tune without code changes.
 - The model and provider are defined in the service configuration (same pattern as the extraction agents).
 - The value of `M` defaults to `Ns` (computed at runtime). A service-level configuration override is allowed if a different ratio is ever needed.
+- **`MAX_GENERATION_ITERATIONS`** — maximum number of generate → verify cycles (including the first pass). Configured in the service `Config` class. Default: `3`.
 
 ---
 
@@ -184,9 +196,10 @@ The following endpoints are used:
 2. **Seed words — one per sentence:** By default `M = Ns`. Each sentence is generated around one seed word. This produces focused, natural sentences rather than forcing unrelated words together.
 3. **No forced word combinations:** Multiple seed words may appear in the same sentence only if they fit together naturally. The agent must never construct artificial sentences purely to include several vocabulary words.
 4. **Inflected forms are acceptable:** A seed word stored in dictionary form (e.g. `"at lave"`) may appear in any grammatically correct conjugated or inflected form in the generated sentence (e.g. `laver`, `lavede`, `lavet`). The generated sentence is not required to contain the exact stored string.
-5. **No deduplication:** The same sentence may be generated and stored multiple times across calls. Deduplication is out of scope.
-6. **Provenance:** All sentences produced by this workflow carry `knowledgeSource = "tome-agent"` so they can be distinguished from sentences extracted from source material.
-7. **Verification is mandatory:** The verification step (Step 3) cannot be bypassed. It ensures quality and guards against LLM hallucinations generating incorrect Danish.
+5. **Replacement loop:** If the verification agent rejects sentences, the generation agent is re-invoked to produce replacements, up to `MAX_GENERATION_ITERATIONS` total cycles. The final set may contain fewer than `Ns` sentences if the limit is reached.
+6. **No deduplication:** The same sentence may be generated and stored multiple times across calls. Deduplication is out of scope.
+7. **Provenance:** All sentences produced by this workflow carry `knowledgeSource = "tome-agent"` so they can be distinguished from sentences extracted from source material.
+8. **Verification is mandatory:** The verification step (Step 3) cannot be bypassed. It ensures quality and guards against LLM hallucinations generating incorrect Danish.
 
 ---
 

--- a/docs/specs/language/source-knowledge-extraction.md
+++ b/docs/specs/language/source-knowledge-extraction.md
@@ -5,15 +5,17 @@
 This spec defines how `tome-ms-sources` enables the **Language Learning** use-case of Tome by:
 
 1. **Persisting Data Sources** — storing metadata about a user's learning material (e.g. a Google Doc) in MongoDB.
-2. **Extracting Knowledge** — on demand, fetching the raw text from the source, using an LLM chain (LangChain) to extract vocabulary pairs, and pushing those pairs to `tome-ms-language` in bulk.
+2. **Extracting Knowledge** — on demand, fetching the raw text from the source, using two parallel LLM agents (LangChain) to extract:
+   - **Vocabulary pairs** (words and translations), pushed to `tome-ms-language`.
+   - **Sentences** (phrases and translations found in the source material), also pushed to `tome-ms-language`.
 
 The overall user journey is:
 
-> The user registers a Google Doc as a Data Source, then manually triggers extraction. Extraction reads the document, extracts word-translation pairs, and inserts them into the vocabulary.
+> The user registers a Google Doc as a Data Source, then manually triggers extraction. Extraction reads the document, extracts word-translation pairs and sentence-translation pairs, and inserts them into the respective stores in `tome-ms-language`.
 
 This matches the two-step model described in the [Data Sources in Language Learning](https://github.com/nicolasances/tome/blob/main/docs/capabilities/language/data-sources.md) product doc: **Add** is separate from **Fetch & Process**.
 
-> **Note on repeated extraction:** Triggering extraction more than once on the same source is safe to do — the workflow will re-read the current document and push the results each time. However, because `tome-ms-language` does not deduplicate, repeated extractions will insert duplicate vocabulary entries. This is acceptable; deduplication is out of scope for this spec.
+> **Note on repeated extraction:** Triggering extraction more than once on the same source is safe to do — the workflow will re-read the current document and push the results each time. However, because `tome-ms-language` does not deduplicate, repeated extractions will insert duplicate vocabulary or sentence entries. This is acceptable; deduplication is out of scope for this spec.
 
 ---
 
@@ -161,17 +163,23 @@ Returns a summary of the extraction:
   "sourceId": "664abc123def456789abcdef",
   "wordsExtracted": 42,
   "wordsCreated": 38,
-  "wordsErrored": 4
+  "wordsErrored": 4,
+  "sentencesExtracted": 12,
+  "sentencesCreated": 11,
+  "sentencesErrored": 1
 }
 ```
 
-| Field            | Description                                                                                                                                  |
-|------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
-| `wordsExtracted` | Number of valid word pairs submitted to `tome-ms-language` after LLM output parsing and local validation (pairs with missing fields are not counted) |
-| `wordsCreated`   | Words reported as `"created"` by `tome-ms-language` in the `207` response                                                                   |
-| `wordsErrored`   | Words reported as `"error"` by `tome-ms-language` in the `207` response                                                                     |
+| Field                | Description                                                                                                                                     |
+|----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
+| `wordsExtracted`     | Number of valid word pairs submitted to `tome-ms-language` after LLM output parsing and local validation (pairs with missing fields are not counted) |
+| `wordsCreated`       | Words reported as `"created"` by `tome-ms-language` in the `207` response                                                                      |
+| `wordsErrored`       | Words reported as `"error"` by `tome-ms-language` in the `207` response                                                                        |
+| `sentencesExtracted` | Number of valid sentence pairs submitted to `tome-ms-language` after LLM output parsing and local validation                                    |
+| `sentencesCreated`   | Sentences reported as `"created"` by `tome-ms-language` in the `207` response                                                                  |
+| `sentencesErrored`   | Sentences reported as `"error"` by `tome-ms-language` in the `207` response                                                                    |
 
-`wordsCreated + wordsErrored` must always equal `wordsExtracted`.
+`wordsCreated + wordsErrored` must always equal `wordsExtracted`. `sentencesCreated + sentencesErrored` must always equal `sentencesExtracted`.
 
 #### Error Cases
 
@@ -210,7 +218,7 @@ This step dispatches to a **Source Content Fetcher** selected by the source's `t
 - If the resource cannot be accessed (permission denied, not found, network error), it raises an error that causes `ExtractKnowledge` to return `502`.
 
 **Once the fetcher returns:**
-- If the plain-text string is empty, skip Steps 3–4 and return `200` with all counts at `0`.
+- If the plain-text string is empty, skip Steps 3–5 and return `200` with all counts at `0`.
 
 > **Content length limit:** Plain-text content exceeding **500,000 characters** is rejected with `400` — the source is considered too large to process regardless of type.
 
@@ -245,7 +253,42 @@ Pass the plain-text content (or each chunk) to a LangChain chain configured with
 - The model and provider (e.g. OpenAI, Anthropic, Bedrock) are defined in the service configuration. The LLM API key must be loaded from the secrets manager.
 - The prompt must be treated as a service-level concern and must be easy to tune without code changes (e.g. stored in the service configuration or a dedicated prompt file).
 
-### Step 4 — Post Vocabulary to tome-ms-language
+### Step 4 — LLM Sentence Extraction (LangChain)
+
+Pass the same plain-text content (or each chunk) to a **separate** LangChain agent dedicated to sentence extraction. This agent runs independently from the vocabulary extraction agent (Step 3) — they may run sequentially or in parallel; the implementation may choose.
+
+**Goal:** identify every complete **sentence or phrase** written in the target language (e.g. Danish) that appears in the source material, along with its English translation. The agent must **only extract sentences already present in the text** — it must never invent or synthesise new sentences.
+
+**Translation priority:**
+1. If a translation for the sentence is present in the source material (directly paired with the sentence), use that translation.
+2. If no translation is present in the material, generate the English translation using the LLM based on the Danish sentence.
+
+**Expected LLM output (structured / JSON mode):**
+
+```json
+{
+  "sentences": [
+    {
+      "sentence": "Jeg kan godt lide at læse bøger.",
+      "translation": "I like reading books."
+    },
+    {
+      "sentence": "Hvornår kom du til Danmark?",
+      "translation": "When did you come to Denmark?"
+    }
+  ]
+}
+```
+
+**Validation of LLM output:** each entry must have both `sentence` and `translation` as non-empty strings. Entries that fail this check are silently dropped.
+
+**LLM failure handling:** applies the same retry policy as Step 3 — one retry per failing chunk, skip the chunk on second failure, return `502` only if all chunks fail.
+
+**LLM configuration:** same rules as Step 3 — model and prompt are service-level concerns, easy to tune without code changes. The sentence extraction prompt must be stored in a **separate prompt file** from the vocabulary extraction prompt.
+
+**Deduplication:** duplicate `(sentence, translation)` pairs appearing across chunks are deduplicated (case-insensitive on `sentence`) before being submitted to `tome-ms-language`.
+
+### Step 5 — Post Vocabulary to tome-ms-language
 
 Call `POST /tomelang/vocabulary/{language}/words/batch` on `tome-ms-language` with the extracted words:
 
@@ -270,7 +313,31 @@ The `207 Multi-Status` response contains per-word `status` values (`"created"` o
 
 > **Note on duplicates:** `tome-ms-language` allows multiple translations of the same English word. Deduplication of vocabulary entries across extraction runs is **out of scope** for this service; the vocabulary service is the owner of that concern.
 
-### Step 5 — Update the Data Source Record
+### Step 6 — Post Sentences to tome-ms-language
+
+Call `POST /tomelang/sentences/{language}/batch` on `tome-ms-language` with the extracted sentences:
+
+```json
+{
+  "sentences": [
+    {
+      "sentence": "Jeg kan godt lide at læse bøger.",
+      "translation": "I like reading books.",
+      "knowledgeSource": "664abc123def456789abcdef"
+    }
+  ]
+}
+```
+
+The `knowledgeSource` field must be set to the `sourceId` of the Data Source being extracted.
+
+**Authentication and Correlation:** same rules as Step 5 — forward the user's JWT and include the correlation ID.
+
+If `tome-ms-language` returns any status other than `207`, the sentence submission fails. **This does not abort the overall extraction** — a sentence submission failure is logged and the `sentencesErrored` count reflects the failure, but the extraction response is still `200`. The vocabulary counts already computed in Step 5 are unaffected.
+
+The `207 Multi-Status` response contains per-sentence `status` values (`"created"` or `"error"`). These are counted to populate `sentencesCreated` and `sentencesErrored` in the response.
+
+### Step 7 — Update the Data Source Record
 
 Update `lastExtractedAt` on the source document to the current UTC time (ISO 8601). This update happens whenever the extraction workflow reaches this step — regardless of how many words were extracted or how many errored in `tome-ms-language`. The timestamp reflects "extraction was attempted and the workflow completed", not "all words were created successfully".
 
@@ -316,11 +383,13 @@ The fetcher uses the **GCP Service Account** credentials available to the servic
 
 ## Integration — tome-ms-language
 
-The `tome-ms-language` base URL must be provided via an environment variable or secret (e.g. `TOME_LANGUAGE_URL`). The service calls the following endpoint:
+The `tome-ms-language` base URL must be provided via an environment variable or secret (e.g. `TOME_LANGUAGE_URL`). The service calls the following endpoints:
 
-| Method | Path                                           | Purpose                  |
-|--------|------------------------------------------------|--------------------------|
-| `POST` | `/tomelang/vocabulary/{language}/words/batch`  | Bulk-insert vocabulary   |
+| Method | Path                                             | Purpose                   |
+|--------|--------------------------------------------------|---------------------------|
+| `POST` | `/tomelang/vocabulary/{language}/words/batch`    | Bulk-insert vocabulary    |
+| `POST` | `/tomelang/sentences/{language}/batch`           | Bulk-insert sentences     |
+| `GET`  | `/tomelang/vocabulary/{language}/words/sample`   | Random word sample (used by sentence generation — see [`sentence-generation.md`](./sentence-generation.md)) |
 
 **Authentication:** Forward the user's JWT from the incoming request as `Authorization: Bearer <token>`.
 


### PR DESCRIPTION
## Summary

Adds sentence extraction from source material and on-demand LLM sentence generation to tome-ms-sources.

### Changes

**Issue #8 — Sentence Extraction during Source Ingestion**
- `SentenceExtractionAgent`: LangChain agent that extracts sentence-translation pairs already present in source text chunks
- Updated `extract_knowledge.py`: Step 4 runs sentence extraction in parallel with vocab extraction; Step 6 posts sentences to tome-ms-language (non-fatal on failure)
- Updated API response to include `sentencesExtracted`, `sentencesCreated`, `sentencesErrored`

**Issue #9 — On-Demand Sentence Generation**
- `SentenceGenerationAgent`: Generates one natural Danish sentence per seed vocabulary word
- `SentenceVerificationAgent`: Danish language expert LLM that filters generated sentences for grammar/naturalness, only returning accepted ones
- `generate_sentences.py`: `POST /sentences/generate` — samples `count` vocabulary words, runs a generate→verify retry loop (up to `MAX_GENERATION_ITERATIONS=3`), posts accepted sentences as `knowledgeSource=tome-agent`
- Updated `api/tome_language_api.py`: added `post_sentences()` and `sample_words()`
- Updated `config/config.py`: added `MAX_GENERATION_ITERATIONS` constant and property

Closes #8
Closes #9
Part of toto#158