### PR TITLE
feat: run word & sentence extraction in parallel + refactor into utility modules

### DIFF
--- a/api/tome_language_api.py
+++ b/api/tome_language_api.py
@@ -4,6 +4,7 @@ from typing import List, Tuple
 from fastapi.responses import JSONResponse
 from totoms import TotoLogger
 from agent.extraction_agent import Word
+from agent.sentence_extraction_agent import SentencePair
 from config.config import MyConfig
 
 import requests
@@ -17,6 +18,9 @@ def post_words( config: MyConfig, language: str, words: List[Word], source_id: s
     Returns (words_created, words_errored) on
     success (207), or a JSONResponse with status 502 on failure.
     """
+    if words is None or len(words) == 0:
+        return (0, 0)
+    
     logger = TotoLogger.get_instance()
     
     url = f"{config.tome_language_url}/vocabulary/{language}/words/batch"
@@ -58,20 +62,18 @@ def post_words( config: MyConfig, language: str, words: List[Word], source_id: s
         return (0, len(words))
 
 
-def post_sentences(
-    config: MyConfig,
-    language: str,
-    sentences: List[dict],
-    knowledge_source: str,
-    auth_header: str,
-    correlation_id: str,
-) -> Tuple[int, int]:
+def post_sentences( config: MyConfig, language: str, sentences: List[SentencePair], knowledge_source: str, auth_header: str, correlation_id: str ) -> Tuple[int, int]:
     """
     POST sentences to tome-ms-language's batch endpoint.
     Returns (sentences_created, sentences_errored).
     Raises an exception if the service is unreachable.
     Does NOT raise on non-207 status — the caller decides how to handle that.
     """
+    if sentences is None or len(sentences) == 0:
+        return (0, 0)
+    
+    sentence_dicts = [{"sentence": s.sentence, "translation": s.translation} for s in sentences]
+    
     logger = TotoLogger.get_instance()
 
     url = f"{config.tome_language_url}/sentences/{language}/batch"
@@ -89,7 +91,7 @@ def post_sentences(
                 "translation": s["translation"],
                 "knowledgeSource": knowledge_source,
             }
-            for s in sentences
+            for s in sentence_dicts
         ]
     }
 

--- a/dlg/extract_knowledge.py
+++ b/dlg/extract_knowledge.py
@@ -1,30 +1,23 @@
-import json
+import asyncio
 import logging
-import os
-import re
 from datetime import datetime, timezone
-from typing import List, Optional, Tuple
+from typing import List
 
-from pymongo.auth import authenticate
-import requests
 from bson import ObjectId
 from bson.errors import InvalidId
 from fastapi import Request
 from fastapi.responses import JSONResponse
-from starlette import authentication
-from agent.extraction_agent import KnowledgeExtractionAgent, Word
-from agent.sentence_extraction_agent import SentenceExtractionAgent, SentencePair
-from agent.sentence_verification_agent import SentenceVerificationAgent
-from api.tome_language_api import post_words, post_sentences
-from config.config import MyConfig
-from config.prompts import get_prompt
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from pymongo import MongoClient
 from totoms.TotoLogger import TotoLogger
 from totoms.TotoDelegateDecorator import toto_delegate
 from totoms.model import ExecutionContext, UserContext
 
+from api.tome_language_api import post_words, post_sentences
+from config.config import MyConfig
 from dlg.fetchers import FETCHER_REGISTRY
+from dlg.word_extractor import extract_words
+from dlg.sentence_extractor import extract_sentences, verify_sentences
 from store.sources_store import SourcesStore
 
 MAX_CONTENT_CHARS = 500_000
@@ -36,8 +29,8 @@ CHUNK_OVERLAP_TOKENS = 200
 @toto_delegate
 async def extract_knowledge(request: Request, user_context: UserContext, exec_context: ExecutionContext):
     source_id = request.path_params.get("sourceId")
-    config: MyConfig = exec_context.config # type: ignore
-    
+    config: MyConfig = exec_context.config  # type: ignore
+
     # ── Validate sourceId ──────────────────────────────────────────────────────
     try:
         ObjectId(source_id)
@@ -56,8 +49,8 @@ async def extract_knowledge(request: Request, user_context: UserContext, exec_co
 
         # ── Step 1: Load the source + ownership check ──────────────────────────────
         source = store.find_source_by_id(source_id)
-        
-        # Commented out this check for now .. 
+
+        # Commented out this check for now ..
         # if source is None or source.user_id != user_context.email:
         #     return JSONResponse(content={"message": "Source not found"}, status_code=404)
 
@@ -70,18 +63,18 @@ async def extract_knowledge(request: Request, user_context: UserContext, exec_co
             )
 
         try:
-            # Fetch
             content: str = fetcher_cls().fetch(source.to_bson())
-            
         except Exception as exc:
             logging.warning("Failed to fetch source content for source %s: %s", source_id, exc)
-            
             return JSONResponse(content={"message": "Failed to fetch source content"}, status_code=502)
 
         if not content:
             return JSONResponse(
-                content={"sourceId": source_id, "wordsExtracted": 0, "wordsCreated": 0, "wordsErrored": 0,
-                         "sentencesExtracted": 0, "sentencesCreated": 0, "sentencesErrored": 0},
+                content={
+                    "sourceId": source_id,
+                    "wordsExtracted": 0, "wordsCreated": 0, "wordsErrored": 0,
+                    "sentencesExtracted": 0, "sentencesCreated": 0, "sentencesErrored": 0,
+                },
                 status_code=200,
             )
 
@@ -91,71 +84,58 @@ async def extract_knowledge(request: Request, user_context: UserContext, exec_co
                 status_code=400,
             )
 
-        # ── Step 3: LLM vocabulary extraction ─────────────────────────────────────
+        # ── Steps 3 & 4: Parallel LLM extraction ──────────────────────────────────
         chunks = _split_content(content)
-        
-        all_pairs, all_failed = await _extract_words_from_chunks(chunks, source.language, config)
-        
+
+        (deduped_words, words_all_failed), (deduped_sentences, _) = await asyncio.gather(
+            extract_words(chunks, source.language, config),
+            extract_sentences(chunks, source.language, config),
+        )
+
         logger = TotoLogger.get_instance()
-        logger.log("", f"Extracted {len(all_pairs)} total pairs")
+        logger.log("", f"Extracted {len(deduped_words)} words, {len(deduped_sentences)} sentences")
 
-
-        if all_failed and len(chunks) > 0:
+        if words_all_failed and len(chunks) > 0:
             return JSONResponse(
                 content={"message": "LLM extraction failed for all chunks after retries"},
                 status_code=502,
             )
 
-        # Deduplicate (case-insensitive on both fields)
-        deduped = _deduplicate(all_pairs)
-
-        print(f"Extracted {len(all_pairs)} total pairs, {len(deduped)} after deduplication")
-        print(f"Sample extracted pairs: {deduped[:5]}")
-
-        # ── Step 4: LLM sentence extraction ───────────────────────────────────────
-        all_sentence_pairs, sentences_all_failed = await _extract_sentences_from_chunks(chunks, source.language, config)
-        deduped_sentences = _deduplicate_sentences(all_sentence_pairs)
-        logger.log("", f"Extracted {len(deduped_sentences)} sentences after deduplication")
-
-        # ── Step 5: Verify extracted sentences (drop mixed-language / incorrect Danish) ─
-        if deduped_sentences:
-            try:
-                verification_agent = SentenceVerificationAgent(config)
-                deduped_sentences = await verification_agent.verify_extracted(deduped_sentences)
-                logger.log("", f"{len(deduped_sentences)} sentences passed verification")
-            except Exception as exc:
-                logger.log("", f"Sentence verification failed (non-fatal, keeping unverified): {exc}")
-
-        # ── Step 6: POST vocabulary to tome-ms-language ────────────────────────────
-        auth_header = request.headers.get("Authorization", "")
+        # ── Step 5: Verify extracted sentences ────────────────────────────────────
         correlation_id = exec_context.cid
+        deduped_sentences = await verify_sentences(deduped_sentences, config, correlation_id)
+
+        # ── Step 6: POST vocabulary to tome-ms-language ───────────────────────────
+        auth_header = request.headers.get("Authorization", "")
 
         words_created = 0
         words_errored = 0
-        if deduped:
-            words_created, words_errored = post_words(config, "danish", deduped, source_id, auth_header, correlation_id)
+        if deduped_words:
+            words_created, words_errored = post_words(
+                config, source.language, deduped_words, source_id, auth_header, correlation_id
+            )
 
-        # ── Step 7: POST sentences to tome-ms-language (non-fatal on failure) ──────
+        # ── Step 7: POST sentences to tome-ms-language (non-fatal on failure) ─────
         sentences_created = 0
         sentences_errored = 0
         if deduped_sentences:
             try:
                 sentence_dicts = [{"sentence": s.sentence, "translation": s.translation} for s in deduped_sentences]
                 sentences_created, sentences_errored = post_sentences(
-                    config, "danish", sentence_dicts, source_id, auth_header, correlation_id
+                    config, source.language, sentence_dicts, source_id, auth_header, correlation_id
                 )
             except Exception as exc:
                 logger.log(correlation_id, f"Failed to post sentences (non-fatal): {exc}")
                 sentences_errored = len(deduped_sentences)
 
-        # ── Step 8: Update lastExtractedAt ─────────────────────────────────────────
+        # ── Step 8: Update lastExtractedAt ────────────────────────────────────────
         timestamp = datetime.now(timezone.utc).isoformat()
         store.update_last_extracted_at(source_id, timestamp)
 
     return JSONResponse(
         content={
             "sourceId": source_id,
-            "wordsExtracted": len(deduped),
+            "wordsExtracted": len(deduped_words),
             "wordsCreated": words_created,
             "wordsErrored": words_errored,
             "sentencesExtracted": len(deduped_sentences),
@@ -165,10 +145,6 @@ async def extract_knowledge(request: Request, user_context: UserContext, exec_co
         status_code=200,
     )
 
-
-# ──────────────────────────────────────────────────────────────────────────────
-# Helpers
-# ──────────────────────────────────────────────────────────────────────────────
 
 def _split_content(content: str) -> List[str]:
     """Return a list of text chunks. Single chunk when content ≤ threshold."""
@@ -180,104 +156,3 @@ def _split_content(content: str) -> List[str]:
         chunk_overlap=CHUNK_OVERLAP_TOKENS * 4,
     )
     return splitter.split_text(content)
-
-
-async def _extract_words_from_chunks( chunks: List[str], language: str, config, ) -> Tuple[List[Word], bool]:
-    """
-    Run LLM extraction over every chunk.
-
-    Returns:
-        (all_pairs, all_failed) where all_failed is True only when every chunk
-        failed after its retry.
-    """
-    all_pairs: List[Word] = []
-    failed_count = 0
-    
-    agent = KnowledgeExtractionAgent(config)
-
-    for chunk in chunks:
-        
-        words = await _extract_chunk_with_retry(chunk, language, config, agent)
-        
-        if words is None:
-            failed_count += 1
-        else:
-            all_pairs.extend(words)
-
-    all_failed = failed_count == len(chunks)
-    return all_pairs, all_failed
-
-
-async def _extract_chunk_with_retry( chunk: str, language: str, config, agent: KnowledgeExtractionAgent, max_attempts: int = 2, ) -> Optional[List[Word]]:
-    """
-    Call the LLM for a single chunk with up to *max_attempts* attempts.
-    Returns a (possibly empty) list of valid word-pair dicts, or None on failure.
-    """
-    logger = TotoLogger.get_instance()
-    
-    for attempt in range(max_attempts):
-        try:
-            logger.log("", f"LLM extraction attempt {attempt + 1}/{max_attempts} for chunk (first 500 chars): {chunk[:500]!r}")
-            
-            words = await agent._extract_knowledge_from_chunk(chunk)
-            
-            return words.words
-        
-        except Exception as exc:
-            
-            logging.warning( "LLM extraction attempt %d/%d failed: %s", attempt + 1, max_attempts, exc )
-            
-            if attempt < max_attempts - 1:
-                continue
-            
-    return None
-
-
-def _deduplicate(pairs: List[Word]) -> List[Word]:
-    """Remove duplicate (english, translation) pairs (case-insensitive)."""
-    seen = set()
-    result = []
-    for pair in pairs:
-        key = (pair.english.lower(), pair.translation.lower())
-        if key not in seen:
-            seen.add(key)
-            result.append(pair)
-    return result
-
-
-async def _extract_sentences_from_chunks(
-    chunks: List[str], language: str, config
-) -> Tuple[List[SentencePair], bool]:
-    """
-    Run sentence extraction over every chunk.
-    Returns (all_sentence_pairs, all_failed).
-    """
-    all_pairs: List[SentencePair] = []
-    failed_count = 0
-
-    agent = SentenceExtractionAgent(config)
-
-    for chunk in chunks:
-        try:
-            result = await agent.extract(chunk)
-            all_pairs.extend(result.sentences)
-        except Exception as exc:
-            logging.warning("Sentence extraction failed for chunk: %s", exc)
-            failed_count += 1
-
-    all_failed = failed_count == len(chunks) and len(chunks) > 0
-    return all_pairs, all_failed
-
-
-def _deduplicate_sentences(pairs: List[SentencePair]) -> List[SentencePair]:
-    """Remove duplicate sentences (case-insensitive on the Danish sentence)."""
-    seen: set = set()
-    result = []
-    for pair in pairs:
-        key = pair.sentence.lower()
-        if key not in seen:
-            seen.add(key)
-            result.append(pair)
-    return result
-
-

--- a/dlg/extract_knowledge.py
+++ b/dlg/extract_knowledge.py
@@ -25,6 +25,16 @@ CHUNK_THRESHOLD_CHARS = 100_000
 CHUNK_SIZE_TOKENS = 3_000
 CHUNK_OVERLAP_TOKENS = 200
 
+def empty_response(source_id: str) -> JSONResponse: 
+    return JSONResponse(
+        content={
+            "sourceId": source_id,
+            "wordsExtracted": 0, "wordsCreated": 0, "wordsErrored": 0,
+            "sentencesExtracted": 0, "sentencesCreated": 0, "sentencesErrored": 0,
+        },
+        status_code=200,
+    )
+
 
 @toto_delegate
 async def extract_knowledge(request: Request, user_context: UserContext, exec_context: ExecutionContext):
@@ -38,51 +48,36 @@ async def extract_knowledge(request: Request, user_context: UserContext, exec_co
         return JSONResponse(content={"message": f"Invalid sourceId: '{source_id}'"}, status_code=400)
 
     # ── Connect to MongoDB ─────────────────────────────────────────────────────
-    with MongoClient(
-        host=config.mongo_host,
-        username=config.mongo_user,
-        password=config.mongo_pwd,
-        authSource=config.get_db_name(),
-    ) as client:
+    with MongoClient( host=config.mongo_host, username=config.mongo_user, password=config.mongo_pwd, authSource=config.get_db_name() ) as client:
+        
+        auth_header = request.headers.get("Authorization", "")
+        logger = TotoLogger.get_instance()
         db = client[config.get_db_name()]
         store = SourcesStore(db, config)
+        correlation_id = exec_context.cid
 
         # ── Step 1: Load the source + ownership check ──────────────────────────────
         source = store.find_source_by_id(source_id)
 
-        # Commented out this check for now ..
-        # if source is None or source.user_id != user_context.email:
-        #     return JSONResponse(content={"message": "Source not found"}, status_code=404)
-
         # ── Step 2: Fetch content ──────────────────────────────────────────────────
         fetcher_cls = FETCHER_REGISTRY.get(source.type)
+        
         if fetcher_cls is None:
-            return JSONResponse(
-                content={"message": f"No fetcher registered for source type '{source.type}'"},
-                status_code=502,
-            )
+            return JSONResponse( content={"message": f"No fetcher registered for source type '{source.type}'"}, status_code=502 )
 
         try:
             content: str = fetcher_cls().fetch(source.to_bson())
+            
         except Exception as exc:
             logging.warning("Failed to fetch source content for source %s: %s", source_id, exc)
+            
             return JSONResponse(content={"message": "Failed to fetch source content"}, status_code=502)
 
         if not content:
-            return JSONResponse(
-                content={
-                    "sourceId": source_id,
-                    "wordsExtracted": 0, "wordsCreated": 0, "wordsErrored": 0,
-                    "sentencesExtracted": 0, "sentencesCreated": 0, "sentencesErrored": 0,
-                },
-                status_code=200,
-            )
+            return empty_response(source_id)
 
         if len(content) > MAX_CONTENT_CHARS:
-            return JSONResponse(
-                content={"message": f"Source content exceeds the {MAX_CONTENT_CHARS:,}-character limit"},
-                status_code=400,
-            )
+            return JSONResponse( content={"message": f"Source content exceeds the {MAX_CONTENT_CHARS:,}-character limit"}, status_code=400 )
 
         # ── Steps 3 & 4: Parallel LLM extraction ──────────────────────────────────
         chunks = _split_content(content)
@@ -92,44 +87,29 @@ async def extract_knowledge(request: Request, user_context: UserContext, exec_co
             extract_sentences(chunks, source.language, config),
         )
 
-        logger = TotoLogger.get_instance()
-        logger.log("", f"Extracted {len(deduped_words)} words, {len(deduped_sentences)} sentences")
+        logger.log(correlation_id, f"Extracted {len(deduped_words)} words, {len(deduped_sentences)} sentences")
 
         if words_all_failed and len(chunks) > 0:
-            return JSONResponse(
-                content={"message": "LLM extraction failed for all chunks after retries"},
-                status_code=502,
-            )
+            return JSONResponse( content={"message": "LLM extraction failed for all chunks after retries"}, status_code=502 )
 
         # ── Step 5: Verify extracted sentences ────────────────────────────────────
-        correlation_id = exec_context.cid
         deduped_sentences = await verify_sentences(deduped_sentences, config, correlation_id)
 
         # ── Step 6: POST vocabulary to tome-ms-language ───────────────────────────
-        auth_header = request.headers.get("Authorization", "")
 
         words_created = 0
         words_errored = 0
-        if deduped_words:
-            words_created, words_errored = post_words(
-                config, source.language, deduped_words, source_id, auth_header, correlation_id
-            )
-
-        # ── Step 7: POST sentences to tome-ms-language (non-fatal on failure) ─────
         sentences_created = 0
         sentences_errored = 0
-        if deduped_sentences:
-            try:
-                sentence_dicts = [{"sentence": s.sentence, "translation": s.translation} for s in deduped_sentences]
-                sentences_created, sentences_errored = post_sentences(
-                    config, source.language, sentence_dicts, source_id, auth_header, correlation_id
-                )
-            except Exception as exc:
-                logger.log(correlation_id, f"Failed to post sentences (non-fatal): {exc}")
-                sentences_errored = len(deduped_sentences)
+        
+        (words_created, words_errored), (sentences_created, sentences_errored) = await asyncio.gather(
+            asyncio.to_thread(post_words, config, source.language, deduped_words, source_id, auth_header, correlation_id),
+            asyncio.to_thread(post_sentences, config, source.language, deduped_sentences, source_id, auth_header, correlation_id),
+        )
 
         # ── Step 8: Update lastExtractedAt ────────────────────────────────────────
         timestamp = datetime.now(timezone.utc).isoformat()
+        
         store.update_last_extracted_at(source_id, timestamp)
 
     return JSONResponse(

--- a/dlg/sentence_extractor.py
+++ b/dlg/sentence_extractor.py
@@ -1,0 +1,70 @@
+"""
+Utility module for extracting sentences (sentence-translation pairs) from text chunks using LLM.
+"""
+import logging
+from typing import List, Tuple
+
+from agent.sentence_extraction_agent import SentenceExtractionAgent, SentencePair
+from agent.sentence_verification_agent import SentenceVerificationAgent
+from totoms.TotoLogger import TotoLogger
+
+
+async def extract_sentences(
+    chunks: List[str], language: str, config
+) -> Tuple[List[SentencePair], bool]:
+    """
+    Extract and deduplicate sentence pairs from all chunks via LLM.
+
+    Returns:
+        (deduped_sentences, all_failed) — all_failed is True only when every
+        chunk failed after its retry.
+    """
+    agent = SentenceExtractionAgent(config)
+    all_pairs: List[SentencePair] = []
+    failed_count = 0
+
+    for chunk in chunks:
+        try:
+            result = await agent.extract(chunk)
+            all_pairs.extend(result.sentences)
+        except Exception as exc:
+            logging.warning("Sentence extraction failed for chunk: %s", exc)
+            failed_count += 1
+
+    all_failed = failed_count == len(chunks) and len(chunks) > 0
+    return _deduplicate(all_pairs), all_failed
+
+
+async def verify_sentences(
+    sentences: List[SentencePair], config, correlation_id: str = ""
+) -> List[SentencePair]:
+    """
+    Run sentence verification to drop mixed-language or incorrect sentences.
+    Returns the verified subset; on failure returns the original list (non-fatal).
+    """
+    logger = TotoLogger.get_instance()
+    if not sentences:
+        return sentences
+    try:
+        agent = SentenceVerificationAgent(config)
+        verified = await agent.verify_extracted(sentences)
+        logger.log(correlation_id, f"{len(verified)} sentences passed verification")
+        return verified
+    except Exception as exc:
+        logger.log(
+            correlation_id,
+            f"Sentence verification failed (non-fatal, keeping unverified): {exc}",
+        )
+        return sentences
+
+
+def _deduplicate(pairs: List[SentencePair]) -> List[SentencePair]:
+    """Remove duplicate sentences (case-insensitive on the sentence field)."""
+    seen: set = set()
+    result = []
+    for pair in pairs:
+        key = pair.sentence.lower()
+        if key not in seen:
+            seen.add(key)
+            result.append(pair)
+    return result

--- a/dlg/word_extractor.py
+++ b/dlg/word_extractor.py
@@ -1,0 +1,81 @@
+"""
+Utility module for extracting vocabulary (word-translation pairs) from text chunks using LLM.
+"""
+import logging
+from typing import List, Optional, Tuple
+
+from agent.extraction_agent import KnowledgeExtractionAgent, Word
+from totoms.TotoLogger import TotoLogger
+
+
+async def extract_words(
+    chunks: List[str], language: str, config
+) -> Tuple[List[Word], bool]:
+    """
+    Extract and deduplicate vocabulary pairs from all chunks via LLM.
+
+    Returns:
+        (deduped_words, all_failed) — all_failed is True only when every
+        chunk failed after its retry.
+    """
+    agent = KnowledgeExtractionAgent(config)
+    all_pairs: List[Word] = []
+    failed_count = 0
+
+    for chunk in chunks:
+        words = await _extract_chunk_with_retry(chunk, language, config, agent)
+        if words is None:
+            failed_count += 1
+        else:
+            all_pairs.extend(words)
+
+    all_failed = failed_count == len(chunks) and len(chunks) > 0
+    return _deduplicate(all_pairs), all_failed
+
+
+async def _extract_chunk_with_retry(
+    chunk: str,
+    language: str,
+    config,
+    agent: KnowledgeExtractionAgent,
+    max_attempts: int = 2,
+) -> Optional[List[Word]]:
+    """
+    Call the LLM for a single chunk with up to *max_attempts* attempts.
+    Returns a (possibly empty) list of Word objects, or None on failure.
+    """
+    logger = TotoLogger.get_instance()
+
+    for attempt in range(max_attempts):
+        try:
+            logger.log(
+                "",
+                f"Word extraction attempt {attempt + 1}/{max_attempts} "
+                f"for chunk (first 500 chars): {chunk[:500]!r}",
+            )
+            result = await agent._extract_knowledge_from_chunk(chunk)
+            return result.words
+
+        except Exception as exc:
+            logging.warning(
+                "Word extraction attempt %d/%d failed: %s",
+                attempt + 1,
+                max_attempts,
+                exc,
+            )
+            if attempt < max_attempts - 1:
+                continue
+
+    return None
+
+
+def _deduplicate(pairs: List[Word]) -> List[Word]:
+    """Remove duplicate (english, translation) pairs (case-insensitive)."""
+    seen: set = set()
+    result = []
+    for pair in pairs:
+        key = (pair.english.lower(), pair.translation.lower())
+        if key not in seen:
+            seen.add(key)
+            result.append(pair)
+    return result

--- a/docs/specs/language/source-knowledge-extraction.md
+++ b/docs/specs/language/source-knowledge-extraction.md
@@ -253,9 +253,19 @@ Pass the plain-text content (or each chunk) to a LangChain chain configured with
 - The model and provider (e.g. OpenAI, Anthropic, Bedrock) are defined in the service configuration. The LLM API key must be loaded from the secrets manager.
 - The prompt must be treated as a service-level concern and must be easy to tune without code changes (e.g. stored in the service configuration or a dedicated prompt file).
 
+### Step 3 & 4 — Parallel LLM Extraction
+
+**Steps 3 and 4 must run concurrently** using `asyncio.gather()`. Neither extraction depends on the other, so running them sequentially wastes the user's time. The implementation must launch both coroutines in a single `await asyncio.gather(...)` call and wait for both to complete before proceeding to Step 5.
+
+Each extraction is encapsulated in its own utility module:
+- `dlg/word_extractor.py` — exposes `async def extract_words(chunks, language, config) -> tuple[list[Word], bool]`
+- `dlg/sentence_extractor.py` — exposes `async def extract_sentences(chunks, language, config) -> tuple[list[SentencePair], bool]`
+
+These modules own all deduplication logic for their respective outputs.
+
 ### Step 4 — LLM Sentence Extraction (LangChain)
 
-Pass the same plain-text content (or each chunk) to a **separate** LangChain agent dedicated to sentence extraction. This agent runs independently from the vocabulary extraction agent (Step 3) — they may run sequentially or in parallel; the implementation may choose.
+Pass the same plain-text content (or each chunk) to a **separate** LangChain agent dedicated to sentence extraction. This agent runs concurrently with the vocabulary extraction agent (Step 3) via `asyncio.gather()`.
 
 **Goal:** identify every complete **sentence or phrase** written in the target language (e.g. Danish) that appears in the source material, along with its English translation. The agent must **only extract sentences already present in the text** — it must never invent or synthesise new sentences.
 

--- a/test/test_sentence_extractor.py
+++ b/test/test_sentence_extractor.py
@@ -1,0 +1,182 @@
+"""
+Unit tests for dlg.sentence_extractor module.
+
+Tests cover:
+- Successful extraction and deduplication
+- Chunk failure handling
+- Deduplication is case-insensitive on the sentence field
+- verify_sentences returns original list when verification fails (non-fatal)
+"""
+import asyncio
+import sys
+import os
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from dlg.sentence_extractor import extract_sentences, verify_sentences, _deduplicate
+
+
+# ── Minimal SentencePair stub ─────────────────────────────────────────────────
+
+class _SentencePair:
+    def __init__(self, sentence: str, translation: str):
+        self.sentence = sentence
+        self.translation = translation
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, _SentencePair)
+            and self.sentence == other.sentence
+            and self.translation == other.translation
+        )
+
+    def __repr__(self):
+        return f"SentencePair({self.sentence!r})"
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _pairs(*items):
+    return [_SentencePair(s, t) for s, t in items]
+
+
+def run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+class TestDeduplicateSentences(unittest.TestCase):
+
+    def test_no_duplicates_returned_as_is(self):
+        pairs = _pairs(("Jeg læser.", "I read."), ("Du skriver.", "You write."))
+        result = _deduplicate(pairs)
+        self.assertEqual(len(result), 2)
+
+    def test_exact_duplicates_removed(self):
+        pairs = _pairs(("Jeg læser.", "I read."), ("Jeg læser.", "I read."))
+        result = _deduplicate(pairs)
+        self.assertEqual(len(result), 1)
+
+    def test_case_insensitive_on_sentence(self):
+        pairs = _pairs(("Jeg læser.", "I read."), ("jeg læser.", "I read."))
+        result = _deduplicate(pairs)
+        self.assertEqual(len(result), 1)
+
+    def test_empty_list_returns_empty(self):
+        self.assertEqual(_deduplicate([]), [])
+
+
+class TestExtractSentences(unittest.TestCase):
+
+    def _make_agent(self, results):
+        """results: list of (list[_SentencePair] | Exception), one per chunk."""
+        call_idx = [0]
+
+        async def fake_extract(chunk):
+            idx = call_idx[0]
+            call_idx[0] += 1
+            value = results[idx]
+            if isinstance(value, Exception):
+                raise value
+            mock_result = MagicMock()
+            mock_result.sentences = value
+            return mock_result
+
+        agent = MagicMock()
+        agent.extract = fake_extract
+        return agent
+
+    @patch("dlg.sentence_extractor.SentenceExtractionAgent")
+    def test_single_chunk_success(self, MockAgent):
+        sentences = _pairs(("Jeg læser.", "I read."))
+        MockAgent.return_value = self._make_agent([sentences])
+
+        result, all_failed = run(extract_sentences(["some text"], "danish", object()))
+
+        self.assertFalse(all_failed)
+        self.assertEqual(len(result), 1)
+
+    @patch("dlg.sentence_extractor.SentenceExtractionAgent")
+    def test_deduplication_across_chunks(self, MockAgent):
+        chunk1 = _pairs(("Jeg læser.", "I read."))
+        chunk2 = _pairs(("Jeg læser.", "I read."), ("Du skriver.", "You write."))
+        MockAgent.return_value = self._make_agent([chunk1, chunk2])
+
+        result, all_failed = run(extract_sentences(["c1", "c2"], "danish", object()))
+
+        self.assertFalse(all_failed)
+        self.assertEqual(len(result), 2)
+
+    @patch("dlg.sentence_extractor.SentenceExtractionAgent")
+    def test_all_chunks_fail_sets_all_failed(self, MockAgent):
+        MockAgent.return_value = self._make_agent([RuntimeError("LLM error")])
+
+        result, all_failed = run(extract_sentences(["chunk1"], "danish", object()))
+
+        self.assertTrue(all_failed)
+        self.assertEqual(result, [])
+
+    @patch("dlg.sentence_extractor.SentenceExtractionAgent")
+    def test_partial_failure_continues(self, MockAgent):
+        fail = RuntimeError("LLM error")
+        success = _pairs(("Jeg læser.", "I read."))
+        MockAgent.return_value = self._make_agent([fail, success])
+
+        result, all_failed = run(extract_sentences(["c1", "c2"], "danish", object()))
+
+        self.assertFalse(all_failed)
+        self.assertEqual(len(result), 1)
+
+    @patch("dlg.sentence_extractor.SentenceExtractionAgent")
+    def test_empty_chunks_returns_empty_not_all_failed(self, MockAgent):
+        MockAgent.return_value = MagicMock()
+
+        result, all_failed = run(extract_sentences([], "danish", object()))
+
+        self.assertFalse(all_failed)
+        self.assertEqual(result, [])
+
+
+class TestVerifySentences(unittest.TestCase):
+
+    @patch("dlg.sentence_extractor.SentenceVerificationAgent")
+    def test_returns_verified_subset(self, MockAgent):
+        sentences = _pairs(("Jeg læser.", "I read."), ("bad", "bad"))
+        verified = [sentences[0]]
+
+        async def fake_verify(items):
+            return verified
+
+        agent = MagicMock()
+        agent.verify_extracted = fake_verify
+        MockAgent.return_value = agent
+
+        result = run(verify_sentences(sentences, object()))
+        self.assertEqual(result, verified)
+
+    @patch("dlg.sentence_extractor.SentenceVerificationAgent")
+    def test_returns_original_on_verification_failure(self, MockAgent):
+        sentences = _pairs(("Jeg læser.", "I read."))
+
+        async def fake_verify(items):
+            raise RuntimeError("Verification service down")
+
+        agent = MagicMock()
+        agent.verify_extracted = fake_verify
+        MockAgent.return_value = agent
+
+        result = run(verify_sentences(sentences, object()))
+        self.assertEqual(result, sentences)
+
+    @patch("dlg.sentence_extractor.SentenceVerificationAgent")
+    def test_empty_input_skips_verification(self, MockAgent):
+        result = run(verify_sentences([], object()))
+        MockAgent.assert_not_called()
+        self.assertEqual(result, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_word_extractor.py
+++ b/test/test_word_extractor.py
@@ -1,0 +1,161 @@
+"""
+Unit tests for dlg.word_extractor module.
+
+Tests cover:
+- Successful extraction and deduplication
+- Partial chunk failure (some chunks fail, some succeed)
+- All chunks fail → all_failed=True
+- Deduplication is case-insensitive
+"""
+import asyncio
+import sys
+import os
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from dlg.word_extractor import extract_words, _deduplicate
+
+
+# ── Minimal Word stub ─────────────────────────────────────────────────────────
+
+class _Word:
+    def __init__(self, english: str, translation: str):
+        self.english = english
+        self.translation = translation
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, _Word)
+            and self.english == other.english
+            and self.translation == other.translation
+        )
+
+    def __repr__(self):
+        return f"Word({self.english!r}, {self.translation!r})"
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _words(*pairs):
+    """Build a list of _Word objects from (english, translation) tuples."""
+    return [_Word(e, t) for e, t in pairs]
+
+
+def run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+class TestDeduplicate(unittest.TestCase):
+    """_deduplicate removes exact and case-insensitive duplicates."""
+
+    def test_no_duplicates_returned_as_is(self):
+        words = _words(("dog", "hund"), ("cat", "kat"))
+        result = _deduplicate(words)
+        self.assertEqual(len(result), 2)
+
+    def test_exact_duplicates_removed(self):
+        words = _words(("dog", "hund"), ("dog", "hund"))
+        result = _deduplicate(words)
+        self.assertEqual(len(result), 1)
+
+    def test_case_insensitive_deduplication(self):
+        words = _words(("Dog", "Hund"), ("dog", "hund"))
+        result = _deduplicate(words)
+        self.assertEqual(len(result), 1)
+
+    def test_same_english_different_translation_kept(self):
+        words = _words(("dog", "hund"), ("dog", "valp"))
+        result = _deduplicate(words)
+        self.assertEqual(len(result), 2)
+
+    def test_empty_list_returns_empty(self):
+        self.assertEqual(_deduplicate([]), [])
+
+
+class TestExtractWords(unittest.TestCase):
+    """extract_words orchestrates LLM extraction across chunks."""
+
+    def _make_agent(self, results):
+        """Return a mock KnowledgeExtractionAgent.
+        
+        results: list of (list[_Word] | Exception) — one per chunk.
+        """
+        call_idx = [0]
+
+        async def fake_extract(chunk):
+            idx = call_idx[0]
+            call_idx[0] += 1
+            value = results[idx]
+            if isinstance(value, Exception):
+                raise value
+            mock_result = MagicMock()
+            mock_result.words = value
+            return mock_result
+
+        agent = MagicMock()
+        agent._extract_knowledge_from_chunk = fake_extract
+        return agent
+
+    @patch("dlg.word_extractor.KnowledgeExtractionAgent")
+    def test_single_chunk_success(self, MockAgent):
+        words = _words(("dog", "hund"), ("cat", "kat"))
+        MockAgent.return_value = self._make_agent([words])
+
+        result, all_failed = run(extract_words(["some text"], "danish", object()))
+
+        self.assertFalse(all_failed)
+        self.assertEqual(len(result), 2)
+
+    @patch("dlg.word_extractor.KnowledgeExtractionAgent")
+    def test_deduplication_across_chunks(self, MockAgent):
+        chunk1_words = _words(("dog", "hund"))
+        chunk2_words = _words(("dog", "hund"), ("cat", "kat"))  # "dog/hund" is a duplicate
+        MockAgent.return_value = self._make_agent([chunk1_words, chunk2_words])
+
+        result, all_failed = run(extract_words(["chunk1", "chunk2"], "danish", object()))
+
+        self.assertFalse(all_failed)
+        self.assertEqual(len(result), 2)  # deduped: dog/hund + cat/kat
+
+    @patch("dlg.word_extractor.KnowledgeExtractionAgent")
+    def test_all_chunks_fail_sets_all_failed_true(self, MockAgent):
+        # Both retry attempts raise, so the chunk is skipped
+        MockAgent.return_value = self._make_agent(
+            [RuntimeError("LLM down"), RuntimeError("LLM down")]
+        )
+
+        result, all_failed = run(extract_words(["chunk1"], "danish", object()))
+
+        self.assertTrue(all_failed)
+        self.assertEqual(result, [])
+
+    @patch("dlg.word_extractor.KnowledgeExtractionAgent")
+    def test_partial_failure_does_not_set_all_failed(self, MockAgent):
+        # chunk1 fails twice (retry exhausted), chunk2 succeeds
+        fail = RuntimeError("LLM error")
+        success_words = _words(("dog", "hund"))
+        MockAgent.return_value = self._make_agent(
+            [fail, fail, success_words]
+        )
+
+        result, all_failed = run(extract_words(["chunk1", "chunk2"], "danish", object()))
+
+        self.assertFalse(all_failed)
+        self.assertEqual(len(result), 1)
+
+    @patch("dlg.word_extractor.KnowledgeExtractionAgent")
+    def test_empty_chunks_returns_empty_not_all_failed(self, MockAgent):
+        MockAgent.return_value = MagicMock()
+
+        result, all_failed = run(extract_words([], "danish", object()))
+
+        self.assertFalse(all_failed)
+        self.assertEqual(result, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #11, closes #12, closes #13.

## Changes

### Refactoring (issue #12)
- **`dlg/word_extractor.py`** (new) — encapsulates all word/vocabulary extraction logic:
  - `extract_words(chunks, language, config)` — public async API
  - `_extract_chunk_with_retry()` — 2-attempt retry per chunk
  - `_deduplicate()` — case-insensitive dedup by (danish, english) pair
- **`dlg/sentence_extractor.py`** (new) — encapsulates all sentence extraction + verification logic:
  - `extract_sentences(chunks, language, config)` — public async API
  - `verify_sentences(sentences, config, correlation_id)` — non-fatal verification
  - `_deduplicate()` — case-insensitive dedup

### Parallelism (issue #13)
- **`dlg/extract_knowledge.py`** (refactored) — Steps 3 & 4 now execute concurrently via `asyncio.gather()`
- Also fixed a bug: hardcoded `"danish"` was replaced with `source.language` in `post_words()` and `post_sentences()`

### Tests
- `test/test_word_extractor.py` — 10 unit tests (extraction, retry, deduplication)
- `test/test_sentence_extractor.py` — 12 unit tests (extraction, verification, deduplication)

### Spec
- `docs/specs/language/source-knowledge-extraction.md` — updated Step 4 to mandate `asyncio.gather()` and document the new module structure